### PR TITLE
Implement timesheet backend APIs and modernized frontend UI

### DIFF
--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -1,0 +1,120 @@
+import { neon } from '@neondatabase/serverless';
+
+type Sql = ReturnType<typeof neon>;
+
+export const json = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+
+export function readCookie(header: string, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(/; */)) {
+    const [k, ...rest] = part.split('=');
+    if (k === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+export async function verifyJwt(token: string, secret: string): Promise<Record<string, any>> {
+  const enc = new TextEncoder();
+  const [h, p, s] = token.split('.');
+  if (!h || !p || !s) throw new Error('bad_token');
+
+  const base64urlToBytes = (str: string) => {
+    const pad = '='.repeat((4 - (str.length % 4)) % 4);
+    const b64 = (str + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  };
+
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+  const ok = await crypto.subtle.verify('HMAC', key, base64urlToBytes(s), enc.encode(data));
+  if (!ok) throw new Error('bad_sig');
+
+  const payload = JSON.parse(new TextDecoder().decode(base64urlToBytes(p)));
+  if ((payload as any)?.exp && Date.now() / 1000 > (payload as any).exp) throw new Error('expired');
+  return payload as Record<string, any>;
+}
+
+export async function requireTimesheetActor(request: Request, env: any, sql: Sql) {
+  const cookieHeader = request.headers.get('cookie') || '';
+  const token = readCookie(cookieHeader, '__Host-rp_session');
+  if (!token) return { error: json({ ok: false, error: 'no_cookie' }, 401) };
+
+  const payload = await verifyJwt(token, String(env.JWT_SECRET));
+  const actor_user_id = String((payload as any).sub || '');
+  if (!actor_user_id) return { error: json({ ok: false, error: 'bad_token' }, 401) };
+
+  const tenant_id = request.headers.get('x-tenant-id');
+  if (!tenant_id) return { error: json({ ok: false, error: 'missing_tenant' }, 400) };
+
+  const rows = await sql<{
+    role: string;
+    active: boolean;
+    can_timekeeping: boolean;
+    can_edit_timesheet: boolean;
+    login_id: string;
+    name: string;
+  }[]>`
+    SELECT
+      m.role,
+      m.active,
+      COALESCE(p.can_timekeeping, false) AS can_timekeeping,
+      COALESCE(p.can_edit_timesheet, false) AS can_edit_timesheet,
+      u.login_id,
+      u.name
+    FROM app.memberships m
+    JOIN app.users u ON u.user_id = m.user_id
+    LEFT JOIN app.permissions p ON p.user_id = m.user_id
+    WHERE m.tenant_id = ${tenant_id} AND m.user_id = ${actor_user_id}
+    LIMIT 1
+  `;
+
+  if (!rows.length || rows[0].active === false) return { error: json({ ok: false, error: 'forbidden' }, 403) };
+  if (!rows[0].can_timekeeping) return { error: json({ ok: false, error: 'timesheet_denied' }, 403) };
+
+  return {
+    actor: {
+      actor_user_id,
+      tenant_id,
+      role: rows[0].role,
+      can_timekeeping: rows[0].can_timekeeping,
+      can_edit_timesheet: rows[0].can_edit_timesheet,
+      login_id: rows[0].login_id,
+      name: rows[0].name,
+    },
+  };
+}
+
+export function toIsoOrNull(v: any): string | null {
+  if (v == null || v === '') return null;
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+export function dayBounds(dateStr?: string) {
+  const d = dateStr ? new Date(`${dateStr}T00:00:00.000Z`) : new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const base = `${y}-${m}-${day}`;
+  return {
+    date: base,
+    startIso: `${base}T00:00:00.000Z`,
+    endIso: `${base}T23:59:59.999Z`,
+  };
+}
+
+export function makeEntryId() {
+  return `te_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/functions/api/timesheet/admin-edit.ts
+++ b/functions/api/timesheet/admin-edit.ts
@@ -1,0 +1,48 @@
+import { neon } from '@neondatabase/serverless';
+import { json, requireTimesheetActor, toIsoOrNull } from './_helpers';
+
+export const onRequestPost: PagesFunction = async ({ request, env }) => {
+  try {
+    const sql = neon(String(env.DATABASE_URL));
+    const auth = await requireTimesheetActor(request, env, sql);
+    if ('error' in auth) return auth.error;
+    const { actor } = auth;
+
+    if (!actor.can_edit_timesheet) return json({ ok: false, error: 'edit_denied' }, 403);
+
+    const body = await request.json().catch(() => ({}));
+    const entry_id = String(body?.entry_id || '').trim();
+    if (!entry_id) return json({ ok: false, error: 'entry_id_required' }, 400);
+
+    const rows = await sql/*sql*/`
+      SELECT te.entry_id
+      FROM app.time_entries te
+      JOIN app.users u ON u.login_id = te.login_id
+      JOIN app.memberships m ON m.user_id = u.user_id
+      WHERE m.tenant_id = ${actor.tenant_id}
+        AND te.entry_id = ${entry_id}
+      LIMIT 1
+    `;
+    if (!rows.length) return json({ ok: false, error: 'entry_not_found' }, 404);
+
+    const nowIso = new Date().toISOString();
+    await sql/*sql*/`
+      UPDATE app.time_entries
+      SET
+        clock_in = ${toIsoOrNull(body?.clock_in)},
+        lunch_out = ${toIsoOrNull(body?.lunch_out)},
+        lunch_in = ${toIsoOrNull(body?.lunch_in)},
+        clock_out = ${toIsoOrNull(body?.clock_out)},
+        notes = ${body?.notes == null ? null : String(body.notes)},
+        status = ${body?.status == null ? null : String(body.status)},
+        edited_by = ${actor.login_id},
+        edited_at = ${nowIso},
+        updated_at = ${nowIso}
+      WHERE entry_id = ${entry_id}
+    `;
+
+    return json({ ok: true });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};

--- a/functions/api/timesheet/admin-list.ts
+++ b/functions/api/timesheet/admin-list.ts
@@ -1,0 +1,32 @@
+import { neon } from '@neondatabase/serverless';
+import { dayBounds, json, requireTimesheetActor } from './_helpers';
+
+export const onRequestGet: PagesFunction = async ({ request, env }) => {
+  try {
+    const sql = neon(String(env.DATABASE_URL));
+    const auth = await requireTimesheetActor(request, env, sql);
+    if ('error' in auth) return auth.error;
+    const { actor } = auth;
+
+    if (!actor.can_edit_timesheet) return json({ ok: false, error: 'edit_denied' }, 403);
+
+    const url = new URL(request.url);
+    const date = url.searchParams.get('date') || undefined;
+    const bounds = dayBounds(date);
+
+    const rows = await sql/*sql*/`
+      SELECT te.*
+      FROM app.time_entries te
+      JOIN app.users u ON u.login_id = te.login_id
+      JOIN app.memberships m ON m.user_id = u.user_id
+      WHERE m.tenant_id = ${actor.tenant_id}
+        AND te.clock_in >= ${bounds.startIso}
+        AND te.clock_in <= ${bounds.endIso}
+      ORDER BY COALESCE(te.user_name, te.login_id), te.clock_in
+    `;
+
+    return json({ ok: true, date: bounds.date, entries: rows });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};

--- a/functions/api/timesheet/me.ts
+++ b/functions/api/timesheet/me.ts
@@ -1,0 +1,46 @@
+import { neon } from '@neondatabase/serverless';
+import { dayBounds, json, requireTimesheetActor } from './_helpers';
+
+export const onRequestGet: PagesFunction = async ({ request, env }) => {
+  try {
+    const sql = neon(String(env.DATABASE_URL));
+    const auth = await requireTimesheetActor(request, env, sql);
+    if ('error' in auth) return auth.error;
+
+    const { actor, } = auth;
+    const today = dayBounds();
+
+    const todayRows = await sql/*sql*/`
+      SELECT *
+      FROM app.time_entries
+      WHERE login_id = ${actor.login_id}
+        AND clock_in >= ${today.startIso}
+        AND clock_in <= ${today.endIso}
+      ORDER BY updated_at DESC NULLS LAST
+      LIMIT 1
+    `;
+
+    const periodStart = new Date(today.startIso);
+    periodStart.setUTCDate(periodStart.getUTCDate() - 13);
+    const periodStartIso = periodStart.toISOString();
+
+    const periodRows = await sql/*sql*/`
+      SELECT *
+      FROM app.time_entries
+      WHERE login_id = ${actor.login_id}
+        AND clock_in >= ${periodStartIso}
+        AND clock_in <= ${today.endIso}
+      ORDER BY clock_in DESC NULLS LAST
+      LIMIT 30
+    `;
+
+    return json({
+      ok: true,
+      actor,
+      today: todayRows[0] || null,
+      period_entries: periodRows,
+    });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};

--- a/functions/api/timesheet/punch.ts
+++ b/functions/api/timesheet/punch.ts
@@ -1,0 +1,80 @@
+import { neon } from '@neondatabase/serverless';
+import { dayBounds, json, makeEntryId, requireTimesheetActor } from './_helpers';
+
+export const onRequestPost: PagesFunction = async ({ request, env }) => {
+  try {
+    const sql = neon(String(env.DATABASE_URL));
+    const auth = await requireTimesheetActor(request, env, sql);
+    if ('error' in auth) return auth.error;
+    const { actor } = auth;
+
+    const body = await request.json().catch(() => ({}));
+    const action = String(body?.action || '').trim();
+    if (!['clock_in', 'lunch_out', 'lunch_in', 'clock_out'].includes(action)) {
+      return json({ ok: false, error: 'invalid_action' }, 400);
+    }
+
+    const nowIso = new Date().toISOString();
+    const today = dayBounds();
+
+    const existingRows = await sql/*sql*/`
+      SELECT *
+      FROM app.time_entries
+      WHERE login_id = ${actor.login_id}
+        AND clock_in >= ${today.startIso}
+        AND clock_in <= ${today.endIso}
+      ORDER BY updated_at DESC NULLS LAST
+      LIMIT 1
+    `;
+
+    const existing = existingRows[0] || null;
+
+    if (!existing && action !== 'clock_in') return json({ ok: false, error: 'clock_in_required' }, 400);
+
+    if (!existing && action === 'clock_in') {
+      const entry_id = makeEntryId();
+      await sql/*sql*/`
+        INSERT INTO app.time_entries (
+          entry_id, user_name, login_id, clock_in, status, updated_at, notes
+        ) VALUES (
+          ${entry_id}, ${actor.name}, ${actor.login_id}, ${nowIso}, ${'open'}, ${nowIso}, ${null}
+        )
+      `;
+    } else if (action === 'lunch_out') {
+      if (existing.lunch_out) return json({ ok: false, error: 'already_punched' }, 400);
+      await sql/*sql*/`
+        UPDATE app.time_entries
+        SET lunch_out = ${nowIso}, status = ${'open'}, updated_at = ${nowIso}
+        WHERE entry_id = ${existing.entry_id}
+      `;
+    } else if (action === 'lunch_in') {
+      if (!existing.lunch_out) return json({ ok: false, error: 'lunch_out_required' }, 400);
+      if (existing.lunch_in) return json({ ok: false, error: 'already_punched' }, 400);
+      await sql/*sql*/`
+        UPDATE app.time_entries
+        SET lunch_in = ${nowIso}, status = ${'open'}, updated_at = ${nowIso}
+        WHERE entry_id = ${existing.entry_id}
+      `;
+    } else if (action === 'clock_out') {
+      if (existing.clock_out) return json({ ok: false, error: 'already_punched' }, 400);
+      await sql/*sql*/`
+        UPDATE app.time_entries
+        SET clock_out = ${nowIso}, status = ${'complete'}, updated_at = ${nowIso}
+        WHERE entry_id = ${existing.entry_id}
+      `;
+    }
+
+    const row = await sql/*sql*/`
+      SELECT * FROM app.time_entries
+      WHERE login_id = ${actor.login_id}
+        AND clock_in >= ${today.startIso}
+        AND clock_in <= ${today.endIso}
+      ORDER BY updated_at DESC NULLS LAST
+      LIMIT 1
+    `;
+
+    return json({ ok: true, entry: row[0] || null });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};

--- a/screens/timesheet.html
+++ b/screens/timesheet.html
@@ -1,101 +1,60 @@
-<!-- screens/timesheet.html -->
 <section class="rp-screen rp-timesheet">
   <style>
-    /* Ported from your old Apps Script Timesheet theme/styles */
-    :root{
-      --brand: #2563eb; --brand-600:#1d4ed8; --brand-700:#1e40af;
-      --ok: #10b981; --ok-600:#059669;
-      --warn: #f59e0b; --warn-600:#d97706;
-      --info: #3b82f6; --info-600:#2563eb;
-      --danger:#ef4444; --danger-600:#dc2626;
-      --fg:#111827; --muted:#6b7280; --border:#e5e7eb;
-      --bg:#ffffff; --bg-soft:#f9fafb;
-      --shadow: 0 8px 20px rgba(0,0,0,0.06);
-      --radius: 10px;
-    }
-    .rp-timesheet{ background:var(--bg); color:var(--fg); }
-    .rp-timesheet h2{ margin:0 0 12px 0; }
+    .rp-timesheet{max-width:1100px}
+    .card{border:1px solid #e5e7eb;border-radius:10px;padding:12px;margin:10px 0;background:#fff}
     .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-    .card{border:1px solid var(--border);border-radius:var(--radius);padding:12px;background:#fff;margin-top:12px;box-shadow:var(--shadow)}
-    .muted{color:var(--muted)}
-    .pill{border:1px solid var(--border);border-radius:999px;padding:4px 10px;font-size:12px;background:var(--bg-soft)}
-    .status { padding: 6px 12px; border-radius: 6px; display: inline-block; margin-bottom: 10px; }
-    .status.open { background: #fff7ed; color:#9a3412; border:1px solid #fed7aa;}
-    .status.complete { background: #ecfdf5; color:#065f46; border:1px solid #bbf7d0;}
-    .status.needsreview { background: #fef2f2; color:#991b1b; border:1px solid #fecaca;}
-    table { border-collapse: collapse; width: 100%; margin-top: 15px; background:#fff; border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow) }
-    th, td { border: 1px solid var(--border); padding: 10px; text-align: center; }
-    th{background:var(--bg-soft); font-weight:600}
-    .actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
-    .btn{
-      --btn-bg:#fff; --btn-fg:var(--fg); --btn-bd:var(--border); --btn-bg-h:#fff; --btn-bd-h:var(--border);
-      display:inline-flex; align-items:center; justify-content:center; gap:8px;
-      padding:10px 16px; border-radius:10px; font-weight:600; border:1px solid var(--btn-bd);
-      background:var(--btn-bg); color:var(--btn-fg); cursor:pointer; transition:all .15s ease;
-      box-shadow:0 2px 6px rgba(0,0,0,0.04);
-    }
-    .btn:hover{ background:var(--btn-bg-h); border-color:var(--btn-bd-h); transform:translateY(-1px) }
-    .btn:active{ transform:translateY(0) }
-    .btn:disabled{ opacity:.5; cursor:not-allowed; transform:none }
-    .btn-primary{ --btn-bg:var(--brand); --btn-fg:#fff; --btn-bd:var(--brand);
-                  --btn-bg-h:linear-gradient(180deg,var(--brand) 0%, var(--brand-600) 100%); --btn-bd-h:var(--brand-700) }
-    .btn-success{ --btn-bg:var(--ok); --btn-fg:#fff; --btn-bd:var(--ok);
-                  --btn-bg-h:linear-gradient(180deg,var(--ok) 0%, var(--ok-600) 100%); --btn-bd-h:var(--ok-600) }
-    .btn-warning{ --btn-bg:var(--warn); --btn-fg:#111; --btn-bd:var(--warn);
-                  --btn-bg-h:linear-gradient(180deg,var(--warn) 0%, var(--warn-600) 100%); --btn-bd-h:var(--warn-600) }
-    .btn-info{    --btn-bg:var(--info); --btn-fg:#fff; --btn-bd:var(--info);
-                  --btn-bg-h:linear-gradient(180deg,var(--info) 0%, var(--info-600) 100%); --btn-bd-h:var(--info-600) }
-    .btn-danger{  --btn-bg:var(--danger); --btn-fg:#fff; --btn-bd:var(--danger);
-                  --btn-bg-h:linear-gradient(180deg,var(--danger) 0%, var(--danger-600) 100%); --btn-bd-h:var(--danger-600) }
-    .btn-ghost{   --btn-bg:#fff; --btn-fg:var(--fg); --btn-bd:var(--border);
-                  --btn-bg-h:#fff; --btn-bd-h:#cbd5e1 }
-
-    input[type="text"], input[type="date"]{
-      border:1px solid var(--border);border-radius:8px;padding:10px 12px;outline:none
-    }
-    input[type="text"]:focus, input[type="date"]:focus{ border-color:var(--brand); box-shadow:0 0 0 3px rgba(37,99,235,.15) }
-    .log { font-size: 12px; color: var(--muted); margin-top: 20px; white-space: pre-wrap; background: var(--bg-soft); padding: 10px; border: 1px solid var(--border); border-radius:var(--radius) }
-
-    /* Working overlay (matches your UX requirement: disable + spinner overlay) */
-    .rp-busy {
-      position: fixed; inset: 0; display:none; align-items:center; justify-content:center;
-      background: rgba(255,255,255,0.75); backdrop-filter: blur(2px); z-index: 9999;
-    }
-    .rp-busy[aria-hidden="false"]{ display:flex; }
-    .rp-busy .box{
-      border:1px solid var(--border); border-radius: 14px; background:#fff; box-shadow: var(--shadow);
-      padding: 14px 16px; font-weight: 700;
-    }
+    .btn{padding:9px 13px;border-radius:8px;border:1px solid #d1d5db;background:#fff;cursor:pointer;font-weight:600}
+    .btn:disabled{opacity:.55;cursor:not-allowed}
+    .btn-primary{background:#2563eb;color:#fff;border-color:#2563eb}
+    .btn-success{background:#059669;color:#fff;border-color:#059669}
+    .btn-warning{background:#d97706;color:#fff;border-color:#d97706}
+    .btn-danger{background:#dc2626;color:#fff;border-color:#dc2626}
+    .pill{display:inline-block;padding:4px 10px;border-radius:999px;background:#f3f4f6;font-size:12px}
+    .muted{color:#6b7280}
+    table{width:100%;border-collapse:collapse}
+    th,td{border:1px solid #e5e7eb;padding:8px;text-align:left}
+    th{background:#f9fafb}
+    input,select{padding:8px;border:1px solid #d1d5db;border-radius:8px}
+    .busy{display:none;position:fixed;inset:0;background:rgba(255,255,255,.7);z-index:9999;align-items:center;justify-content:center}
+    .busy.show{display:flex}
+    .busy span{padding:10px 14px;background:#fff;border:1px solid #e5e7eb;border-radius:10px}
+    .log{font-size:12px;white-space:pre-wrap;background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;padding:10px}
   </style>
 
-  <div class="rp-busy" id="rpBusy" aria-hidden="true" aria-live="polite" aria-busy="false">
-    <div class="box">Working…</div>
-  </div>
+  <div id="busy" class="busy"><span>Working…</span></div>
 
-  <h2>Resell Pro – TimeSheet</h2>
+  <h2>Timesheet</h2>
+  <div id="today"></div>
 
-  <div id="today">Loading today…</div>
-
-  <div id="mgrBox" class="card" style="display:none">
-    <div class="row"><strong>Manager Edit</strong> <span class="muted">(edit any employee/date)</span></div>
+  <div class="card">
+    <div class="row" style="justify-content:space-between">
+      <strong>Today</strong>
+      <span id="todayStatus" class="pill">Loading…</span>
+    </div>
+    <div id="todayTimes" class="muted" style="margin:8px 0"></div>
     <div class="row">
-      <input id="mgrLogin" placeholder="Login ID (e.g. mblock)" />
-      <input id="mgrDate" type="date" />
-      <input id="mgrIn" placeholder="Clock In (e.g. 9:00 AM)" />
-      <input id="mgrLout" placeholder="Lunch Out (e.g. 12:00 PM)" />
-      <input id="mgrLin" placeholder="Lunch In (e.g. 12:30 PM)" />
-      <input id="mgrOut" placeholder="Clock Out (e.g. 5:45 PM)" />
-    </div>
-    <div class="row" style="margin-top:6px;">
-      <input id="mgrNote" style="flex:1" placeholder="Note for audit…" />
-      <button class="btn btn-primary" id="btnMgrSave">Save</button>
+      <button id="btnClockIn" class="btn btn-primary">Clock In</button>
+      <button id="btnLunchOut" class="btn btn-warning">Clock Out For Lunch</button>
+      <button id="btnLunchIn" class="btn btn-success">Clock In From Lunch</button>
+      <button id="btnClockOut" class="btn btn-danger">Clock Out</button>
     </div>
   </div>
 
-  <h3>This Pay Period</h3>
-  <table id="periodTable"></table>
+  <div class="card">
+    <strong>My Recent Entries</strong>
+    <table id="myTable" style="margin-top:8px"></table>
+  </div>
 
-  <div id="logs" class="log"></div>
+  <div class="card" id="adminCard" style="display:none">
+    <div class="row" style="justify-content:space-between">
+      <strong>Edit Entries (Tenant)</strong>
+      <div class="row">
+        <input id="adminDate" type="date" />
+        <button id="btnAdminLoad" class="btn">Load</button>
+      </div>
+    </div>
+    <table id="adminTable" style="margin-top:8px"></table>
+  </div>
 
- 
+  <div id="logs" class="log" style="margin-top:10px"></div>
 </section>

--- a/screens/timesheet.js
+++ b/screens/timesheet.js
@@ -1,175 +1,230 @@
-// screens/timesheet.js
 import { api } from '/assets/js/api.js';
 import { showToast } from '/assets/js/ui.js';
 
 let els = {};
-let sessionUser = null;
+let state = {
+  actor: null,
+  todayEntry: null,
+  periodEntries: [],
+  canEdit: false,
+};
 
-export async function init({ container, session }) {
-  sessionUser = session?.user || null;
+export async function init({ container }) {
   bind(container);
   wire();
-  setTodayBanner();
-  renderPayPeriodTable();
-  await checkApiHealth();
+  setBanner();
+  await loadMe();
 }
 
 function bind(container) {
   els = {
-    root: container,
     today: container.querySelector('#today'),
-    mgrBox: container.querySelector('#mgrBox'),
-    mgrLogin: container.querySelector('#mgrLogin'),
-    mgrDate: container.querySelector('#mgrDate'),
-    mgrIn: container.querySelector('#mgrIn'),
-    mgrLout: container.querySelector('#mgrLout'),
-    mgrLin: container.querySelector('#mgrLin'),
-    mgrOut: container.querySelector('#mgrOut'),
-    mgrNote: container.querySelector('#mgrNote'),
-    btnMgrSave: container.querySelector('#btnMgrSave'),
-    periodTable: container.querySelector('#periodTable'),
+    todayStatus: container.querySelector('#todayStatus'),
+    todayTimes: container.querySelector('#todayTimes'),
+    btnClockIn: container.querySelector('#btnClockIn'),
+    btnLunchOut: container.querySelector('#btnLunchOut'),
+    btnLunchIn: container.querySelector('#btnLunchIn'),
+    btnClockOut: container.querySelector('#btnClockOut'),
+    myTable: container.querySelector('#myTable'),
+    adminCard: container.querySelector('#adminCard'),
+    adminDate: container.querySelector('#adminDate'),
+    btnAdminLoad: container.querySelector('#btnAdminLoad'),
+    adminTable: container.querySelector('#adminTable'),
+    busy: container.querySelector('#busy'),
     logs: container.querySelector('#logs'),
-    busy: container.querySelector('#rpBusy'),
   };
 }
 
 function wire() {
-  toggleManagerSection();
-
-  if (els.btnMgrSave) {
-    els.btnMgrSave.addEventListener('click', onManagerSave);
-  }
+  els.btnClockIn?.addEventListener('click', () => punch('clock_in'));
+  els.btnLunchOut?.addEventListener('click', () => punch('lunch_out'));
+  els.btnLunchIn?.addEventListener('click', () => punch('lunch_in'));
+  els.btnClockOut?.addEventListener('click', () => punch('clock_out'));
+  els.btnAdminLoad?.addEventListener('click', loadAdmin);
 }
 
-function setTodayBanner() {
-  if (!els.today) return;
+function setBanner() {
   const now = new Date();
-  els.today.textContent = `Today is ${now.toLocaleDateString(undefined, {
-    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
-  })}.`;
-}
-
-function toggleManagerSection() {
-  if (!els.mgrBox) return;
-
-  // Support either role-based or permission-based user payloads.
-  const role = String(sessionUser?.role || '').toLowerCase();
-  const perms = sessionUser?.permissions || {};
-  const canManage = role === 'manager' || role === 'admin' || !!perms?.can_settings;
-
-  els.mgrBox.style.display = canManage ? '' : 'none';
-}
-
-function renderPayPeriodTable() {
-  if (!els.periodTable) return;
-
-  const start = getPayPeriodStart(new Date());
-  const rows = [];
-
-  for (let i = 0; i < 14; i += 1) {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    rows.push({
-      date: d,
-      clockIn: '—',
-      lunchOut: '—',
-      lunchIn: '—',
-      clockOut: '—',
-      total: '—',
-      status: 'Open',
-    });
+  if (els.today) {
+    els.today.textContent = `Today is ${now.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}.`;
   }
-
-  els.periodTable.innerHTML = `
-    <thead>
-      <tr>
-        <th>Date</th>
-        <th>Clock In</th>
-        <th>Lunch Out</th>
-        <th>Lunch In</th>
-        <th>Clock Out</th>
-        <th>Total</th>
-        <th>Status</th>
-      </tr>
-    </thead>
-    <tbody>
-      ${rows.map((r) => `
-        <tr>
-          <td>${r.date.toLocaleDateString()}</td>
-          <td>${r.clockIn}</td>
-          <td>${r.lunchOut}</td>
-          <td>${r.lunchIn}</td>
-          <td>${r.clockOut}</td>
-          <td>${r.total}</td>
-          <td><span class="pill">${r.status}</span></td>
-        </tr>
-      `).join('')}
-    </tbody>
-  `;
-
-  log(`Rendered pay period starting ${start.toDateString()} (14 days).`);
+  if (els.adminDate) els.adminDate.value = isoDate(now);
 }
 
-function getPayPeriodStart(today) {
-  // Biweekly period anchored to Monday, Jan 1, 2024.
-  const anchor = new Date('2024-01-01T00:00:00');
-
-  const current = new Date(today);
-  const day = current.getDay();
-  const diffToMonday = (day + 6) % 7;
-  current.setDate(current.getDate() - diffToMonday);
-  current.setHours(0, 0, 0, 0);
-
-  const daysFromAnchor = Math.floor((current - anchor) / 86400000);
-  const periodOffset = ((daysFromAnchor % 14) + 14) % 14;
-  current.setDate(current.getDate() - periodOffset);
-
-  return current;
-}
-
-async function checkApiHealth() {
+async function loadMe() {
   setBusy(true);
   try {
-    await api('/api/ping', { method: 'GET' });
-    log('API ping ok. Screen wiring is healthy.');
-  } catch (err) {
-    log(`API ping failed (non-blocking): ${err?.message || err}`);
+    const data = await api('/api/timesheet/me');
+    state.actor = data.actor || null;
+    state.todayEntry = data.today || null;
+    state.periodEntries = data.period_entries || [];
+    state.canEdit = !!data?.actor?.can_edit_timesheet;
+
+    renderToday();
+    renderMyTable();
+
+    if (state.canEdit) {
+      els.adminCard.style.display = '';
+      await loadAdmin();
+    } else {
+      els.adminCard.style.display = 'none';
+    }
+  } catch (e) {
+    showToast('Unable to load timesheet.');
+    log(`loadMe failed: ${e?.data?.error || e?.message || e}`);
   } finally {
     setBusy(false);
   }
 }
 
-function onManagerSave() {
-  const payload = {
-    login_id: (els.mgrLogin?.value || '').trim(),
-    date: els.mgrDate?.value || '',
-    clock_in: (els.mgrIn?.value || '').trim(),
-    lunch_out: (els.mgrLout?.value || '').trim(),
-    lunch_in: (els.mgrLin?.value || '').trim(),
-    clock_out: (els.mgrOut?.value || '').trim(),
-    note: (els.mgrNote?.value || '').trim(),
-  };
+async function punch(action) {
+  setBusy(true);
+  try {
+    const res = await api('/api/timesheet/punch', {
+      method: 'POST',
+      body: { action },
+    });
+    state.todayEntry = res.entry || null;
+    await loadMe();
+    showToast('Time updated.');
+  } catch (e) {
+    showToast(e?.data?.error ? `Unable: ${e.data.error}` : 'Unable to save time entry.');
+    log(`punch failed (${action}): ${e?.data?.error || e?.message || e}`);
+  } finally {
+    setBusy(false);
+  }
+}
 
-  if (!payload.login_id || !payload.date) {
-    showToast('Please provide Login ID and Date before saving.');
+function renderToday() {
+  const e = state.todayEntry;
+  const status = e?.status || 'Not started';
+  els.todayStatus.textContent = status;
+
+  els.todayTimes.textContent = [
+    `Clock In: ${fmt(e?.clock_in)}`,
+    `Lunch Out: ${fmt(e?.lunch_out)}`,
+    `Lunch In: ${fmt(e?.lunch_in)}`,
+    `Clock Out: ${fmt(e?.clock_out)}`,
+  ].join(' • ');
+
+  els.btnClockIn.disabled = !!e?.clock_in;
+  els.btnLunchOut.disabled = !e?.clock_in || !!e?.lunch_out;
+  els.btnLunchIn.disabled = !e?.lunch_out || !!e?.lunch_in;
+  els.btnClockOut.disabled = !e?.clock_in || !!e?.clock_out;
+}
+
+function renderMyTable() {
+  const rows = state.periodEntries || [];
+  if (!rows.length) {
+    els.myTable.innerHTML = '<tbody><tr><td class="muted">No entries yet.</td></tr></tbody>';
     return;
   }
 
-  // Endpoint is not implemented in this repository yet.
-  // Keep UX unblocked and log payload for next-step backend hookup.
-  log(`Manager save draft: ${JSON.stringify(payload)}`);
-  showToast('Manager save captured locally. API endpoint hookup is next.');
+  els.myTable.innerHTML = `
+    <thead>
+      <tr>
+        <th>Date</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows.map((r) => `
+        <tr>
+          <td>${fmtDate(r.clock_in)}</td>
+          <td>${fmt(r.clock_in)}</td>
+          <td>${fmt(r.lunch_out)}</td>
+          <td>${fmt(r.lunch_in)}</td>
+          <td>${fmt(r.clock_out)}</td>
+          <td>${escapeHtml(r.status || '')}</td>
+        </tr>
+      `).join('')}
+    </tbody>
+  `;
 }
 
-function setBusy(on) {
-  if (!els.busy) return;
-  els.busy.setAttribute('aria-hidden', on ? 'false' : 'true');
-  els.busy.setAttribute('aria-busy', on ? 'true' : 'false');
+async function loadAdmin() {
+  if (!state.canEdit) return;
+  setBusy(true);
+  try {
+    const q = els.adminDate?.value ? `?date=${encodeURIComponent(els.adminDate.value)}` : '';
+    const data = await api(`/api/timesheet/admin-list${q}`);
+    renderAdminTable(data.entries || []);
+  } catch (e) {
+    showToast('Unable to load tenant entries.');
+    log(`loadAdmin failed: ${e?.data?.error || e?.message || e}`);
+  } finally {
+    setBusy(false);
+  }
 }
 
-function log(message) {
-  if (!els.logs) return;
-  const ts = new Date().toLocaleTimeString();
-  const line = `[${ts}] ${message}`;
-  els.logs.textContent = `${line}\n${els.logs.textContent || ''}`.trim();
+function renderAdminTable(entries) {
+  if (!entries.length) {
+    els.adminTable.innerHTML = '<tbody><tr><td class="muted">No entries for selected date.</td></tr></tbody>';
+    return;
+  }
+
+  els.adminTable.innerHTML = `
+    <thead>
+      <tr>
+        <th>User</th><th>Login</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Status</th><th>Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${entries.map((e) => `
+        <tr data-entry-id="${escapeHtml(e.entry_id)}">
+          <td>${escapeHtml(e.user_name || '')}</td>
+          <td>${escapeHtml(e.login_id || '')}</td>
+          <td><input data-f="clock_in" type="datetime-local" value="${dtLocal(e.clock_in)}" /></td>
+          <td><input data-f="lunch_out" type="datetime-local" value="${dtLocal(e.lunch_out)}" /></td>
+          <td><input data-f="lunch_in" type="datetime-local" value="${dtLocal(e.lunch_in)}" /></td>
+          <td><input data-f="clock_out" type="datetime-local" value="${dtLocal(e.clock_out)}" /></td>
+          <td>
+            <select data-f="status">
+              ${['open', 'complete', 'needsreview', ''].map((v) => `<option value="${v}" ${String(e.status || '') === v ? 'selected' : ''}>${v || '—'}</option>`).join('')}
+            </select>
+          </td>
+          <td><button class="btn" data-save="${escapeHtml(e.entry_id)}">Save</button></td>
+        </tr>
+      `).join('')}
+    </tbody>
+  `;
+
+  els.adminTable.querySelectorAll('[data-save]').forEach((btn) => {
+    btn.addEventListener('click', () => saveAdminRow(btn.getAttribute('data-save')));
+  });
 }
+
+async function saveAdminRow(entryId) {
+  const row = els.adminTable.querySelector(`tr[data-entry-id="${CSS.escape(entryId)}"]`);
+  if (!row) return;
+
+  const payload = {
+    entry_id: entryId,
+    clock_in: fromLocal(row.querySelector('[data-f="clock_in"]')?.value),
+    lunch_out: fromLocal(row.querySelector('[data-f="lunch_out"]')?.value),
+    lunch_in: fromLocal(row.querySelector('[data-f="lunch_in"]')?.value),
+    clock_out: fromLocal(row.querySelector('[data-f="clock_out"]')?.value),
+    status: row.querySelector('[data-f="status"]')?.value || null,
+    notes: null,
+  };
+
+  setBusy(true);
+  try {
+    await api('/api/timesheet/admin-edit', { method: 'POST', body: payload });
+    showToast('Entry updated.');
+    await loadAdmin();
+  } catch (e) {
+    showToast(e?.data?.error ? `Unable: ${e.data.error}` : 'Unable to update entry.');
+    log(`saveAdminRow failed: ${e?.data?.error || e?.message || e}`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+function setBusy(on) { els.busy?.classList.toggle('show', !!on); }
+function fmt(v) { return v ? new Date(v).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : '—'; }
+function fmtDate(v) { return v ? new Date(v).toLocaleDateString() : '—'; }
+function isoDate(d) { return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; }
+function dtLocal(v) { if (!v) return ''; const d = new Date(v); d.setMinutes(d.getMinutes() - d.getTimezoneOffset()); return d.toISOString().slice(0, 16); }
+function fromLocal(v) { return v ? new Date(v).toISOString() : null; }
+function log(msg) { if (els.logs) els.logs.textContent = `[${new Date().toLocaleTimeString()}] ${msg}\n${els.logs.textContent || ''}`.trim(); }
+function escapeHtml(s) { return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }


### PR DESCRIPTION
### Motivation
- Provide a server-side API for timesheet operations (punching, listing, editing, and fetching the current user's entries) and centralize auth/utility helpers. 
- Enable managers to view and edit tenant time entries and allow users to punch in/out from the UI. 
- Replace the legacy timesheet screen with a simplified, more robust client that talks to the new endpoints. 

### Description
- Add `functions/api/timesheet/_helpers.ts` which includes `json`, `readCookie`, `verifyJwt`, `requireTimesheetActor`, `toIsoOrNull`, `dayBounds`, and `makeEntryId` to centralize JWT verification, cookie reading, permission checks, date helpers, and DB wiring using `neon` (see `neon` types referenced via `Sql`).
- Add API endpoints: `punch.ts` (user punch actions `clock_in|lunch_out|lunch_in|clock_out`), `me.ts` (fetch actor, today entry and recent period entries), `admin-list.ts` (tenant-scoped entries by date), and `admin-edit.ts` (manager edit of a time entry), all using `requireTimesheetActor` and SQL queries.
- Replace and simplify frontend screen files `screens/timesheet.html` and `screens/timesheet.js` to match the new APIs, including updated markup, CSS, buttons for punch actions, admin table with `datetime-local` inputs, client-side helpers (`dtLocal`, `fromLocal`, `fmt`, `escapeHtml`), busy state handling, and wiring to new endpoints (`/api/timesheet/*`).
- Add client-side save flow for admin edits which posts to `/api/timesheet/admin-edit` and reloads the admin list from `/api/timesheet/admin-list` after success.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15011b8248331b1df2c87bffa3bc6)