### PR TITLE
Add total-hours calculations and self-service payroll report to Timesheet

### DIFF
--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -118,3 +118,30 @@ export function dayBounds(dateStr?: string) {
 export function makeEntryId() {
   return `te_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }
+
+export function computeTotalHours(input: {
+  clock_in?: string | null;
+  lunch_out?: string | null;
+  lunch_in?: string | null;
+  clock_out?: string | null;
+}): number | null {
+  const clockIn = input?.clock_in ? new Date(input.clock_in) : null;
+  const clockOut = input?.clock_out ? new Date(input.clock_out) : null;
+  const lunchOut = input?.lunch_out ? new Date(input.lunch_out) : null;
+  const lunchIn = input?.lunch_in ? new Date(input.lunch_in) : null;
+
+  if (!clockIn || !clockOut) return null;
+
+  const workedMs = clockOut.getTime() - clockIn.getTime();
+  if (workedMs <= 0) return 0;
+
+  let breakMs = 0;
+  if (lunchOut) {
+    const breakEnd = lunchIn || clockOut;
+    const rawBreak = breakEnd.getTime() - lunchOut.getTime();
+    if (rawBreak > 0) breakMs = rawBreak;
+  }
+
+  const hours = Math.max(0, (workedMs - breakMs) / (1000 * 60 * 60));
+  return Math.round(hours * 100) / 100;
+}

--- a/functions/api/timesheet/admin-edit.ts
+++ b/functions/api/timesheet/admin-edit.ts
@@ -1,5 +1,5 @@
 import { neon } from '@neondatabase/serverless';
-import { json, requireTimesheetActor, toIsoOrNull } from './_helpers';
+import { computeTotalHours, json, requireTimesheetActor, toIsoOrNull } from './_helpers';
 
 export const onRequestPost: PagesFunction = async ({ request, env }) => {
   try {
@@ -13,6 +13,11 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const body = await request.json().catch(() => ({}));
     const entry_id = String(body?.entry_id || '').trim();
     if (!entry_id) return json({ ok: false, error: 'entry_id_required' }, 400);
+    const clock_in = toIsoOrNull(body?.clock_in);
+    const lunch_out = toIsoOrNull(body?.lunch_out);
+    const lunch_in = toIsoOrNull(body?.lunch_in);
+    const clock_out = toIsoOrNull(body?.clock_out);
+    const total_hours = computeTotalHours({ clock_in, lunch_out, lunch_in, clock_out });
 
     const rows = await sql/*sql*/`
       SELECT te.entry_id
@@ -29,10 +34,11 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     await sql/*sql*/`
       UPDATE app.time_entries
       SET
-        clock_in = ${toIsoOrNull(body?.clock_in)},
-        lunch_out = ${toIsoOrNull(body?.lunch_out)},
-        lunch_in = ${toIsoOrNull(body?.lunch_in)},
-        clock_out = ${toIsoOrNull(body?.clock_out)},
+        clock_in = ${clock_in},
+        lunch_out = ${lunch_out},
+        lunch_in = ${lunch_in},
+        clock_out = ${clock_out},
+        total_hours = ${total_hours},
         notes = ${body?.notes == null ? null : String(body.notes)},
         status = ${body?.status == null ? null : String(body.status)},
         edited_by = ${actor.login_id},

--- a/functions/api/timesheet/me.ts
+++ b/functions/api/timesheet/me.ts
@@ -8,6 +8,7 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
     if ('error' in auth) return auth.error;
 
     const { actor, } = auth;
+    const url = new URL(request.url);
     const today = dayBounds();
 
     const todayRows = await sql/*sql*/`
@@ -34,11 +35,33 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
       LIMIT 30
     `;
 
+    const from = (url.searchParams.get('from') || '').trim();
+    const to = (url.searchParams.get('to') || '').trim();
+
+    let range_entries: any[] = [];
+    let range_total_hours = 0;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(from) && /^\d{4}-\d{2}-\d{2}$/.test(to) && from <= to) {
+      const fromBounds = dayBounds(from);
+      const toBounds = dayBounds(to);
+      const rangeRows = await sql/*sql*/`
+        SELECT *
+        FROM app.time_entries
+        WHERE login_id = ${actor.login_id}
+          AND clock_in >= ${fromBounds.startIso}
+          AND clock_in <= ${toBounds.endIso}
+        ORDER BY clock_in DESC NULLS LAST
+      `;
+      range_entries = rangeRows;
+      range_total_hours = rangeRows.reduce((sum, row: any) => sum + Number(row.total_hours || 0), 0);
+    }
+
     return json({
       ok: true,
       actor,
       today: todayRows[0] || null,
       period_entries: periodRows,
+      range_entries,
+      range_total_hours: Math.round(range_total_hours * 100) / 100,
     });
   } catch (e: any) {
     return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);

--- a/functions/api/timesheet/punch.ts
+++ b/functions/api/timesheet/punch.ts
@@ -1,5 +1,5 @@
 import { neon } from '@neondatabase/serverless';
-import { dayBounds, json, makeEntryId, requireTimesheetActor } from './_helpers';
+import { computeTotalHours, dayBounds, json, makeEntryId, requireTimesheetActor } from './_helpers';
 
 export const onRequestPost: PagesFunction = async ({ request, env }) => {
   try {
@@ -33,33 +33,52 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
 
     if (!existing && action === 'clock_in') {
       const entry_id = makeEntryId();
+      const totalHours = computeTotalHours({ clock_in: nowIso, clock_out: null, lunch_out: null, lunch_in: null });
       await sql/*sql*/`
         INSERT INTO app.time_entries (
-          entry_id, user_name, login_id, clock_in, status, updated_at, notes
+          entry_id, user_name, login_id, clock_in, total_hours, status, updated_at, notes
         ) VALUES (
-          ${entry_id}, ${actor.name}, ${actor.login_id}, ${nowIso}, ${'open'}, ${nowIso}, ${null}
+          ${entry_id}, ${actor.name}, ${actor.login_id}, ${nowIso}, ${totalHours}, ${'open'}, ${nowIso}, ${null}
         )
       `;
     } else if (action === 'lunch_out') {
       if (existing.lunch_out) return json({ ok: false, error: 'already_punched' }, 400);
+      const totalHours = computeTotalHours({
+        clock_in: existing.clock_in,
+        lunch_out: nowIso,
+        lunch_in: existing.lunch_in,
+        clock_out: existing.clock_out,
+      });
       await sql/*sql*/`
         UPDATE app.time_entries
-        SET lunch_out = ${nowIso}, status = ${'open'}, updated_at = ${nowIso}
+        SET lunch_out = ${nowIso}, total_hours = ${totalHours}, status = ${'open'}, updated_at = ${nowIso}
         WHERE entry_id = ${existing.entry_id}
       `;
     } else if (action === 'lunch_in') {
       if (!existing.lunch_out) return json({ ok: false, error: 'lunch_out_required' }, 400);
       if (existing.lunch_in) return json({ ok: false, error: 'already_punched' }, 400);
+      const totalHours = computeTotalHours({
+        clock_in: existing.clock_in,
+        lunch_out: existing.lunch_out,
+        lunch_in: nowIso,
+        clock_out: existing.clock_out,
+      });
       await sql/*sql*/`
         UPDATE app.time_entries
-        SET lunch_in = ${nowIso}, status = ${'open'}, updated_at = ${nowIso}
+        SET lunch_in = ${nowIso}, total_hours = ${totalHours}, status = ${'open'}, updated_at = ${nowIso}
         WHERE entry_id = ${existing.entry_id}
       `;
     } else if (action === 'clock_out') {
       if (existing.clock_out) return json({ ok: false, error: 'already_punched' }, 400);
+      const totalHours = computeTotalHours({
+        clock_in: existing.clock_in,
+        lunch_out: existing.lunch_out,
+        lunch_in: existing.lunch_in,
+        clock_out: nowIso,
+      });
       await sql/*sql*/`
         UPDATE app.time_entries
-        SET clock_out = ${nowIso}, status = ${'complete'}, updated_at = ${nowIso}
+        SET clock_out = ${nowIso}, total_hours = ${totalHours}, status = ${'complete'}, updated_at = ${nowIso}
         WHERE entry_id = ${existing.entry_id}
       `;
     }

--- a/screens/timesheet.html
+++ b/screens/timesheet.html
@@ -50,7 +50,19 @@
   <div class="card">
     <strong>My Recent Entries</strong>
     <div class="table-wrap"><table id="myTable"></table></div>
-    <table id="myTable" style="margin-top:8px"></table>
+  </div>
+
+  <div class="card">
+    <div class="row" style="justify-content:space-between">
+      <strong>My Time Report</strong>
+      <div class="row">
+        <label>From <input id="reportFrom" type="date" /></label>
+        <label>To <input id="reportTo" type="date" /></label>
+        <button id="btnReportLoad" class="btn">Run Report</button>
+      </div>
+    </div>
+    <div id="reportTotal" class="muted" style="margin-top:8px"></div>
+    <div class="table-wrap"><table id="reportTable"></table></div>
   </div>
 
   <div class="card" id="adminCard" style="display:none">
@@ -62,7 +74,6 @@
       </div>
     </div>
     <div class="table-wrap"><table id="adminTable"></table></div>
-    <table id="adminTable" style="margin-top:8px"></table>
   </div>
 
   <div id="logs" class="log" style="margin-top:10px"></div>

--- a/screens/timesheet.js
+++ b/screens/timesheet.js
@@ -7,6 +7,8 @@ let state = {
   todayEntry: null,
   periodEntries: [],
   canEdit: false,
+  reportEntries: [],
+  reportTotalHours: 0,
 };
 
 export async function init({ container }) {
@@ -26,6 +28,11 @@ function bind(container) {
     btnLunchIn: container.querySelector('#btnLunchIn'),
     btnClockOut: container.querySelector('#btnClockOut'),
     myTable: container.querySelector('#myTable'),
+    reportFrom: container.querySelector('#reportFrom'),
+    reportTo: container.querySelector('#reportTo'),
+    btnReportLoad: container.querySelector('#btnReportLoad'),
+    reportTotal: container.querySelector('#reportTotal'),
+    reportTable: container.querySelector('#reportTable'),
     adminCard: container.querySelector('#adminCard'),
     adminDate: container.querySelector('#adminDate'),
     btnAdminLoad: container.querySelector('#btnAdminLoad'),
@@ -41,6 +48,7 @@ function wire() {
   els.btnLunchIn?.addEventListener('click', () => punch('lunch_in'));
   els.btnClockOut?.addEventListener('click', () => punch('clock_out'));
   els.btnAdminLoad?.addEventListener('click', loadAdmin);
+  els.btnReportLoad?.addEventListener('click', loadReport);
 }
 
 function setBanner() {
@@ -49,6 +57,12 @@ function setBanner() {
     els.today.textContent = `Today is ${now.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}.`;
   }
   if (els.adminDate) els.adminDate.value = isoDate(now);
+  if (els.reportTo) els.reportTo.value = isoDate(now);
+  if (els.reportFrom) {
+    const from = new Date(now);
+    from.setDate(from.getDate() - 13);
+    els.reportFrom.value = isoDate(from);
+  }
 }
 
 async function loadMe() {
@@ -62,6 +76,7 @@ async function loadMe() {
 
     renderToday();
     renderMyTable();
+    await loadReport();
 
     if (state.canEdit) {
       els.adminCard.style.display = '';
@@ -123,7 +138,7 @@ function renderMyTable() {
   els.myTable.innerHTML = `
     <thead>
       <tr>
-        <th>Date</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Status</th>
+        <th>Date</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Total Hours</th><th>Status</th>
       </tr>
     </thead>
     <tbody>
@@ -134,6 +149,63 @@ function renderMyTable() {
           <td>${fmt(r.lunch_out)}</td>
           <td>${fmt(r.lunch_in)}</td>
           <td>${fmt(r.clock_out)}</td>
+          <td>${fmtHours(r.total_hours)}</td>
+          <td>${escapeHtml(r.status || '')}</td>
+        </tr>
+      `).join('')}
+    </tbody>
+  `;
+}
+
+async function loadReport() {
+  const from = String(els.reportFrom?.value || '').trim();
+  const to = String(els.reportTo?.value || '').trim();
+  if (!from || !to || from > to) {
+    state.reportEntries = [];
+    state.reportTotalHours = 0;
+    renderReportTable();
+    return;
+  }
+
+  setBusy(true);
+  try {
+    const data = await api(`/api/timesheet/me?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`);
+    state.reportEntries = data?.range_entries || [];
+    state.reportTotalHours = Number(data?.range_total_hours || 0);
+    renderReportTable();
+  } catch (e) {
+    showToast('Unable to load time report.');
+    log(`loadReport failed: ${e?.data?.error || e?.message || e}`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+function renderReportTable() {
+  if (els.reportTotal) {
+    els.reportTotal.textContent = `Grand Total (${els.reportFrom?.value || '—'} to ${els.reportTo?.value || '—'}): ${fmtHours(state.reportTotalHours)} hours`;
+  }
+  const rows = state.reportEntries || [];
+  if (!rows.length) {
+    els.reportTable.innerHTML = '<tbody><tr><td class="muted">No entries in selected date range.</td></tr></tbody>';
+    return;
+  }
+
+  els.reportTable.innerHTML = `
+    <thead>
+      <tr>
+        <th>Date</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Total Hours</th><th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows.map((r) => `
+        <tr>
+          <td>${fmtDate(r.clock_in)}</td>
+          <td>${fmt(r.clock_in)}</td>
+          <td>${fmt(r.lunch_out)}</td>
+          <td>${fmt(r.lunch_in)}</td>
+          <td>${fmt(r.clock_out)}</td>
+          <td>${fmtHours(r.total_hours)}</td>
           <td>${escapeHtml(r.status || '')}</td>
         </tr>
       `).join('')}
@@ -165,7 +237,7 @@ function renderAdminTable(entries) {
   els.adminTable.innerHTML = `
     <thead>
       <tr>
-        <th>User</th><th>Login</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Status</th><th>Action</th>
+        <th>User</th><th>Login</th><th>Clock In</th><th>Lunch Out</th><th>Lunch In</th><th>Clock Out</th><th>Total Hours</th><th>Status</th><th>Action</th>
       </tr>
     </thead>
     <tbody>
@@ -177,6 +249,7 @@ function renderAdminTable(entries) {
           <td><input data-f="lunch_out" type="datetime-local" value="${dtLocal(e.lunch_out)}" /></td>
           <td><input data-f="lunch_in" type="datetime-local" value="${dtLocal(e.lunch_in)}" /></td>
           <td><input data-f="clock_out" type="datetime-local" value="${dtLocal(e.clock_out)}" /></td>
+          <td>${fmtHours(e.total_hours)}</td>
           <td>
             <select data-f="status">
               ${['open', 'complete', 'needsreview', ''].map((v) => `<option value="${v}" ${String(e.status || '') === v ? 'selected' : ''}>${v || '—'}</option>`).join('')}
@@ -223,6 +296,7 @@ async function saveAdminRow(entryId) {
 function setBusy(on) { els.busy?.classList.toggle('show', !!on); }
 function fmt(v) { return v ? new Date(v).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : '—'; }
 function fmtDate(v) { return v ? new Date(v).toLocaleDateString() : '—'; }
+function fmtHours(v) { return v == null || v === '' ? '—' : Number(v).toFixed(2); }
 function isoDate(d) { return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; }
 function dtLocal(v) { if (!v) return ''; const d = new Date(v); d.setMinutes(d.getMinutes() - d.getTimezoneOffset()); return d.toISOString().slice(0, 16); }
 function fromLocal(v) { return v ? new Date(v).toISOString() : null; }


### PR DESCRIPTION
### Motivation
- Persist a computed `total_hours` for time entries so worked time (minus breaks) is consistently available in the DB and UI.
- Surface the per-entry totals in both the "My Recent Entries" and admin "Edit Entries (Tenant)" views so users and managers can see hours at a glance.
- Provide a self-service payroll-style report that lets a user query a date range and receive a grand total for payroll reconciliation.

### Description
- Added `computeTotalHours` to `functions/api/timesheet/_helpers.ts` to compute worked hours (clock_out - clock_in minus lunch break) and round to two decimals via `computeTotalHours({ clock_in, lunch_out, lunch_in, clock_out })`.
- Persist `total_hours` on insert/update in the punch flow by updating `functions/api/timesheet/punch.ts` to calculate and write `total_hours` on `clock_in`, `lunch_out`, `lunch_in`, and `clock_out` actions.
- Recalculate and persist `total_hours` on admin edits by updating `functions/api/timesheet/admin-edit.ts` to compute `total_hours` from provided datetimes and write it during the `UPDATE`.
- Added date-range reporting to `functions/api/timesheet/me.ts` that accepts `from` and `to` query params, returns `range_entries`, and a rounded `range_total_hours` grand total, and updated the Timesheet UI (`screens/timesheet.html` and `screens/timesheet.js`) to show `Total Hours` in recent/admin tables and add a `My Time Report` panel with `From`/`To`, `Run Report`, and grand total display.

### Testing
- Ran static checks: `node --check screens/timesheet.js`, `node --check functions/api/timesheet/me.ts`, `node --check functions/api/timesheet/punch.ts`, `node --check functions/api/timesheet/admin-edit.ts`, and `node --check functions/api/timesheet/_helpers.ts`, all succeeded.
- Confirmed schema contains `total_hours` in `app.time_entries` by parsing `Resell Pro NEON SCHEMA.txt` programmatically and verifying the `total_hours` column exists.
- Sanity-checked JS execution paths by running the new UI script checks and the updated API modules with `node --check` to ensure no syntax errors.
- No automated integration tests were available in this environment; manual API/GUI runtime validation is recommended for end-to-end verification (punch flows and date-range report calculations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e197b5c5d483318defca5171667f32)