### PR TITLE
Fix timesheet admin visibility by using client-local day bounds

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -25,6 +25,7 @@ export async function api(path, opts = {}) {
 
   // Attach tenant explicitly from session
   if (ACTIVE_TENANT_ID) headers.set("x-tenant-id", ACTIVE_TENANT_ID);
+  headers.set("x-tz-offset-minutes", String(new Date().getTimezoneOffset()));
 
   // Pass FormData through; JSON-stringify plain objects; otherwise use as-is
   const requestBody = isForm

--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -115,6 +115,43 @@ export function dayBounds(dateStr?: string) {
   };
 }
 
+export function tzOffsetMinutesFromRequest(request: Request): number {
+  const raw = request.headers.get('x-tz-offset-minutes');
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return 0;
+  const rounded = Math.trunc(n);
+  if (rounded < -840 || rounded > 840) return 0;
+  return rounded;
+}
+
+export function localDayBounds(tzOffsetMinutes: number, dateStr?: string) {
+  const offsetMs = tzOffsetMinutes * 60_000;
+  let y: number;
+  let m: number;
+  let d: number;
+
+  if (dateStr && /^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    const [yy, mm, dd] = dateStr.split('-').map((v) => Number(v));
+    y = yy;
+    m = mm;
+    d = dd;
+  } else {
+    const localNow = new Date(Date.now() - offsetMs);
+    y = localNow.getUTCFullYear();
+    m = localNow.getUTCMonth() + 1;
+    d = localNow.getUTCDate();
+  }
+
+  const base = `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+  const startUtc = Date.UTC(y, m - 1, d, 0, 0, 0, 0) + offsetMs;
+  const endUtc = Date.UTC(y, m - 1, d, 23, 59, 59, 999) + offsetMs;
+  return {
+    date: base,
+    startIso: new Date(startUtc).toISOString(),
+    endIso: new Date(endUtc).toISOString(),
+  };
+}
+
 export function makeEntryId() {
   return `te_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }

--- a/functions/api/timesheet/admin-list.ts
+++ b/functions/api/timesheet/admin-list.ts
@@ -1,5 +1,5 @@
 import { neon } from '@neondatabase/serverless';
-import { dayBounds, json, requireTimesheetActor } from './_helpers';
+import { json, localDayBounds, requireTimesheetActor, tzOffsetMinutesFromRequest } from './_helpers';
 
 export const onRequestGet: PagesFunction = async ({ request, env }) => {
   try {
@@ -12,7 +12,8 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
 
     const url = new URL(request.url);
     const date = url.searchParams.get('date') || undefined;
-    const bounds = dayBounds(date);
+    const tzOffsetMinutes = tzOffsetMinutesFromRequest(request);
+    const bounds = localDayBounds(tzOffsetMinutes, date);
 
     const rows = await sql/*sql*/`
       SELECT te.*

--- a/functions/api/timesheet/me.ts
+++ b/functions/api/timesheet/me.ts
@@ -1,5 +1,5 @@
 import { neon } from '@neondatabase/serverless';
-import { dayBounds, json, requireTimesheetActor } from './_helpers';
+import { json, localDayBounds, requireTimesheetActor, tzOffsetMinutesFromRequest } from './_helpers';
 
 export const onRequestGet: PagesFunction = async ({ request, env }) => {
   try {
@@ -9,7 +9,8 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
 
     const { actor, } = auth;
     const url = new URL(request.url);
-    const today = dayBounds();
+    const tzOffsetMinutes = tzOffsetMinutesFromRequest(request);
+    const today = localDayBounds(tzOffsetMinutes);
 
     const todayRows = await sql/*sql*/`
       SELECT *
@@ -41,8 +42,8 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
     let range_entries: any[] = [];
     let range_total_hours = 0;
     if (/^\d{4}-\d{2}-\d{2}$/.test(from) && /^\d{4}-\d{2}-\d{2}$/.test(to) && from <= to) {
-      const fromBounds = dayBounds(from);
-      const toBounds = dayBounds(to);
+      const fromBounds = localDayBounds(tzOffsetMinutes, from);
+      const toBounds = localDayBounds(tzOffsetMinutes, to);
       const rangeRows = await sql/*sql*/`
         SELECT *
         FROM app.time_entries

--- a/functions/api/timesheet/punch.ts
+++ b/functions/api/timesheet/punch.ts
@@ -1,5 +1,5 @@
 import { neon } from '@neondatabase/serverless';
-import { computeTotalHours, dayBounds, json, makeEntryId, requireTimesheetActor } from './_helpers';
+import { computeTotalHours, json, localDayBounds, makeEntryId, requireTimesheetActor, tzOffsetMinutesFromRequest } from './_helpers';
 
 export const onRequestPost: PagesFunction = async ({ request, env }) => {
   try {
@@ -15,7 +15,8 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     }
 
     const nowIso = new Date().toISOString();
-    const today = dayBounds();
+    const tzOffsetMinutes = tzOffsetMinutesFromRequest(request);
+    const today = localDayBounds(tzOffsetMinutes);
 
     const existingRows = await sql/*sql*/`
       SELECT *


### PR DESCRIPTION
### Motivation
- Managers with `can_edit_timesheets = true` could not see other users' entries when entries fell outside UTC calendar-day boundaries, causing missing entries in the admin list and preventing edits.
- The system must compute day windows using the client’s local day so queries include entries created in local evening that map to a different UTC date.

### Description
- Send the client timezone offset on every API request by adding `x-tz-offset-minutes` in `assets/js/api.js`.
- Add `tzOffsetMinutesFromRequest` and `localDayBounds` helpers to `functions/api/timesheet/_helpers.ts` to parse/validate the header and convert a local date into UTC `startIso`/`endIso` bounds.
- Update `/api/timesheet/admin-list` to use `tzOffsetMinutesFromRequest` + `localDayBounds` so tenant-wide admin lists return entries for the selected local date.
- Update `/api/timesheet/me` and `/api/timesheet/punch` to also use the same local-day bounds for consistent "today"/report/punch behavior.

### Testing
- Ran `node --check assets/js/api.js` to validate the modified client API file syntax, and it passed.
- Executed a Node snippet to verify `localDayBounds` produces correct UTC `startIso`/`endIso` ranges for positive and negative timezone offsets, and the results matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19e1ee39c8331b51360a1340fd8a0)