### PR TITLE
Add clock-in requirement flag and dashboard timesheet/status UI

### DIFF
--- a/functions/api/settings/users/create.ts
+++ b/functions/api/settings/users/create.ts
@@ -40,14 +40,14 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     INSERT INTO app.permissions (user_id, name, email, role,
       can_pos, can_cash_drawer, can_cash_payouts, can_item_research,
       can_inventory, can_inventory_intake, can_drop_off_form,
-      can_estimates_buy_tickets, can_timekeeping, can_settings,
+      can_estimates_buy_tickets, can_timekeeping, clockin_required, can_settings,
       notify_cash_drawer, notify_daily_sales_summary, discount_max
     )
     VALUES (
       ${u.user_id}, ${name}, ${email}, ${role},
       ${!!perms.can_pos}, ${!!perms.can_cash_drawer}, ${!!perms.can_cash_payouts}, ${!!perms.can_item_research},
       ${!!perms.can_inventory}, ${!!perms.can_inventory_intake}, ${!!perms.can_drop_off_form},
-      ${!!perms.can_estimates_buy_tickets}, ${!!perms.can_timekeeping}, ${!!perms.can_settings},
+      ${!!perms.can_estimates_buy_tickets}, ${!!perms.can_timekeeping}, ${!!perms.clockin_required}, ${!!perms.can_settings},
       ${!!notes.notify_cash_drawer}, ${!!notes.notify_daily_sales_summary}, ${discount_max}
     )
     ON CONFLICT (user_id) DO UPDATE SET
@@ -56,7 +56,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       can_item_research=EXCLUDED.can_item_research, can_inventory=EXCLUDED.can_inventory,
       can_inventory_intake=EXCLUDED.can_inventory_intake, can_drop_off_form=EXCLUDED.can_drop_off_form,
       can_estimates_buy_tickets=EXCLUDED.can_estimates_buy_tickets, can_timekeeping=EXCLUDED.can_timekeeping,
-      can_settings=EXCLUDED.can_settings, notify_cash_drawer=EXCLUDED.notify_cash_drawer,
+      clockin_required=EXCLUDED.clockin_required, can_settings=EXCLUDED.can_settings, notify_cash_drawer=EXCLUDED.notify_cash_drawer,
       notify_daily_sales_summary=EXCLUDED.notify_daily_sales_summary, discount_max=EXCLUDED.discount_max,
       updated_at=now()
   `;

--- a/functions/api/settings/users/list.ts
+++ b/functions/api/settings/users/list.ts
@@ -96,7 +96,7 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
         m.role, m.active,
         p.can_pos, p.can_cash_drawer, p.can_cash_payouts, p.can_item_research,
         p.can_inventory, p.can_inventory_intake, p.can_drop_off_form,
-        p.can_estimates_buy_tickets, p.can_timekeeping, p.can_settings,
+        p.can_estimates_buy_tickets, p.can_timekeeping, p.clockin_required, p.can_settings,
         p.notify_cash_drawer, p.notify_daily_sales_summary, p.discount_max
       FROM app.memberships m
       JOIN app.users u ON u.user_id = m.user_id

--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -62,6 +62,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
     active: boolean;
     can_timekeeping: boolean;
     can_edit_timesheet: boolean;
+    clockin_required: boolean;
     login_id: string;
     name: string;
   }[]>`
@@ -70,6 +71,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
       m.active,
       COALESCE(p.can_timekeeping, false) AS can_timekeeping,
       COALESCE(p.can_edit_timesheet, false) AS can_edit_timesheet,
+      COALESCE(p.clockin_required, false) AS clockin_required,
       u.login_id,
       u.name
     FROM app.memberships m
@@ -89,6 +91,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
       role: rows[0].role,
       can_timekeeping: rows[0].can_timekeeping,
       can_edit_timesheet: rows[0].can_edit_timesheet,
+      clockin_required: rows[0].clockin_required,
       login_id: rows[0].login_id,
       name: rows[0].name,
     },

--- a/functions/api/timesheet/admin-status.ts
+++ b/functions/api/timesheet/admin-status.ts
@@ -1,0 +1,83 @@
+import { neon } from '@neondatabase/serverless';
+import { json, localDayBounds, requireTimesheetActor, tzOffsetMinutesFromRequest } from './_helpers';
+
+export const onRequestGet: PagesFunction = async ({ request, env }) => {
+  try {
+    const sql = neon(String(env.DATABASE_URL));
+    const auth = await requireTimesheetActor(request, env, sql);
+    if ('error' in auth) return auth.error;
+    const { actor } = auth;
+
+    if (!actor.can_edit_timesheet) return json({ ok: false, error: 'edit_denied' }, 403);
+
+    const tzOffsetMinutes = tzOffsetMinutesFromRequest(request);
+    const today = localDayBounds(tzOffsetMinutes);
+
+    const rows = await sql/*sql*/`
+      WITH tenant_users AS (
+        SELECT u.user_id, u.name, u.login_id
+        FROM app.memberships m
+        JOIN app.users u ON u.user_id = m.user_id
+        WHERE m.tenant_id = ${actor.tenant_id}
+          AND m.active = true
+      ),
+      latest_today AS (
+        SELECT DISTINCT ON (te.login_id)
+          te.login_id,
+          te.clock_in,
+          te.lunch_out,
+          te.lunch_in,
+          te.clock_out,
+          te.status,
+          te.updated_at
+        FROM app.time_entries te
+        WHERE te.clock_in >= ${today.startIso}
+          AND te.clock_in <= ${today.endIso}
+        ORDER BY te.login_id, te.updated_at DESC NULLS LAST
+      ),
+      latest_clock_out AS (
+        SELECT DISTINCT ON (te.login_id)
+          te.login_id,
+          te.clock_out
+        FROM app.time_entries te
+        WHERE te.clock_out IS NOT NULL
+        ORDER BY te.login_id, te.clock_out DESC
+      )
+      SELECT
+        tu.name AS user_name,
+        tu.login_id,
+        lt.clock_in,
+        lt.lunch_out,
+        lt.lunch_in,
+        lt.clock_out,
+        lt.status,
+        lco.clock_out AS last_clock_out
+      FROM tenant_users tu
+      LEFT JOIN latest_today lt ON lt.login_id = tu.login_id
+      LEFT JOIN latest_clock_out lco ON lco.login_id = tu.login_id
+      ORDER BY lower(tu.name), tu.login_id
+    `;
+
+    const statuses = rows.map((r: any) => ({
+      ...r,
+      status_label: toStatusLabel(r),
+    }));
+
+    return json({ ok: true, date: today.date, statuses });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};
+
+function toStatusLabel(entry: {
+  clock_in?: string | null;
+  lunch_out?: string | null;
+  lunch_in?: string | null;
+  clock_out?: string | null;
+}) {
+  if (!entry?.clock_in) return 'Not clocked in';
+  if (entry.clock_out) return 'Clocked out for day';
+  if (entry.lunch_out && !entry.lunch_in) return 'Out to lunch';
+  if (entry.lunch_in) return 'Clocked in from lunch';
+  return 'Clocked in';
+}

--- a/screens/dashboard.html
+++ b/screens/dashboard.html
@@ -1,1 +1,25 @@
-<section class="p-4"><h1>Dashboard</h1><p>Select a feature from the menu.</p></section>
+<section class="p-4" id="dashboardStatusRoot">
+  <h1>Dashboard</h1>
+  <p class="muted" id="dashIntro">Checking your timekeeping status…</p>
+
+  <section class="tile" style="margin-top:12px;">
+    <h3 style="margin-top:0;">My Status</h3>
+    <p id="myStatusLine">—</p>
+    <p id="myLastClockOut" class="muted">Last clock out: —</p>
+    <div style="display:flex; gap:8px; flex-wrap:wrap;">
+      <button id="btnDashboardClockIn" class="btn btn-primary" type="button">Clock In Now</button>
+      <a class="btn btn-ghost" href="?page=timesheet">Open Timesheet</a>
+    </div>
+    <p id="myPrompt" style="display:none; margin-top:8px; color:#b45309; font-weight:600;">
+      You are signed in but not clocked in.
+    </p>
+  </section>
+
+  <section class="tile" id="teamStatusCard" style="margin-top:12px; display:none;">
+    <h3 style="margin-top:0;">Team Status</h3>
+    <p class="muted">Visible to managers/admins with timesheet edit permissions.</p>
+    <div class="table-wrap">
+      <table id="teamStatusTable" class="table"></table>
+    </div>
+  </section>
+</section>

--- a/screens/dashboard.js
+++ b/screens/dashboard.js
@@ -1,2 +1,175 @@
-export async function init(){ /* optional */ }
+import { api } from '/assets/js/api.js';
+import { showToast } from '/assets/js/ui.js';
+
+let els = {};
+let state = {
+  actor: null,
+  todayEntry: null,
+  periodEntries: [],
+  teamStatuses: [],
+};
+
+export async function init({ container }) {
+  bind(container);
+  wire();
+  await loadDashboard();
+}
+
 export function destroy() {}
+
+function bind(container) {
+  els = {
+    dashIntro: container.querySelector('#dashIntro'),
+    myStatusLine: container.querySelector('#myStatusLine'),
+    myLastClockOut: container.querySelector('#myLastClockOut'),
+    btnDashboardClockIn: container.querySelector('#btnDashboardClockIn'),
+    myPrompt: container.querySelector('#myPrompt'),
+    teamStatusCard: container.querySelector('#teamStatusCard'),
+    teamStatusTable: container.querySelector('#teamStatusTable'),
+  };
+}
+
+function wire() {
+  els.btnDashboardClockIn?.addEventListener('click', onClockIn);
+}
+
+async function loadDashboard() {
+  try {
+    const me = await api('/api/timesheet/me');
+    state.actor = me?.actor || null;
+    state.todayEntry = me?.today || null;
+    state.periodEntries = me?.period_entries || [];
+
+    renderMyStatus();
+
+    if (state.actor?.can_edit_timesheet) {
+      els.teamStatusCard.style.display = '';
+      await loadTeamStatus();
+    } else {
+      els.teamStatusCard.style.display = 'none';
+    }
+  } catch (e) {
+    const err = String(e?.data?.error || '');
+    if (err === 'timesheet_denied') {
+      if (els.dashIntro) els.dashIntro.textContent = 'Timekeeping access is not enabled for your account.';
+      if (els.myStatusLine) els.myStatusLine.textContent = 'Status unavailable.';
+      if (els.btnDashboardClockIn) els.btnDashboardClockIn.disabled = true;
+      return;
+    }
+
+    if (els.dashIntro) els.dashIntro.textContent = 'Unable to load your status right now.';
+    if (els.myStatusLine) els.myStatusLine.textContent = 'Status unavailable.';
+  }
+}
+
+async function loadTeamStatus() {
+  try {
+    const data = await api('/api/timesheet/admin-status');
+    state.teamStatuses = data?.statuses || [];
+    renderTeamStatus();
+  } catch {
+    els.teamStatusTable.innerHTML = '<tbody><tr><td class="muted">Unable to load team status.</td></tr></tbody>';
+  }
+}
+
+async function onClockIn() {
+  if (state.todayEntry?.clock_in) return;
+  try {
+    const res = await api('/api/timesheet/punch', {
+      method: 'POST',
+      body: { action: 'clock_in' },
+    });
+    state.todayEntry = res?.entry || state.todayEntry;
+    const at = fmtTime(state.todayEntry?.clock_in);
+    showToast(`Clocked in${at !== '—' ? ` at ${at}` : ''}.`);
+    await loadDashboard();
+  } catch (e) {
+    showToast(e?.data?.error ? `Unable: ${e.data.error}` : 'Unable to clock in.');
+  }
+}
+
+function renderMyStatus() {
+  const entry = state.todayEntry;
+  const status = deriveStatus(entry);
+  const needsPrompt = !!state.actor?.clockin_required && !entry?.clock_in;
+
+  if (els.myStatusLine) els.myStatusLine.textContent = `Current status: ${status.label}`;
+  if (els.dashIntro) {
+    els.dashIntro.textContent = needsPrompt
+      ? 'Please clock in to start your shift.'
+      : 'Your timekeeping status is up to date.';
+  }
+
+  if (els.myPrompt) els.myPrompt.style.display = needsPrompt ? '' : 'none';
+  if (els.btnDashboardClockIn) els.btnDashboardClockIn.disabled = !!entry?.clock_in;
+
+  const lastClockOut = getLastClockOut();
+  if (els.myLastClockOut) {
+    els.myLastClockOut.textContent = `Last clock out: ${lastClockOut ? fmtDateTime(lastClockOut) : '—'}`;
+  }
+}
+
+function renderTeamStatus() {
+  const rows = state.teamStatuses || [];
+  if (!rows.length) {
+    els.teamStatusTable.innerHTML = '<tbody><tr><td class="muted">No users found for this tenant.</td></tr></tbody>';
+    return;
+  }
+
+  els.teamStatusTable.innerHTML = `
+    <thead>
+      <tr>
+        <th>User</th>
+        <th>Login</th>
+        <th>Status</th>
+        <th>Last Clock Out</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows
+        .map((r) => `
+          <tr>
+            <td>${escapeHtml(r.user_name || '')}</td>
+            <td>${escapeHtml(r.login_id || '')}</td>
+            <td>${escapeHtml(r.status_label || 'Not clocked in')}</td>
+            <td>${r.last_clock_out ? escapeHtml(fmtDateTime(r.last_clock_out)) : '—'}</td>
+          </tr>
+        `)
+        .join('')}
+    </tbody>
+  `;
+}
+
+function getLastClockOut() {
+  if (state.todayEntry?.clock_out) return state.todayEntry.clock_out;
+  const prior = (state.periodEntries || []).find((row) => row?.clock_out);
+  return prior?.clock_out || null;
+}
+
+function deriveStatus(entry) {
+  if (!entry?.clock_in) return { key: 'not_clocked_in', label: 'Not clocked in' };
+  if (entry.clock_out) return { key: 'clocked_out', label: `Clocked out for day at ${fmtTime(entry.clock_out)}` };
+  if (entry.lunch_out && !entry.lunch_in) return { key: 'lunch_out', label: `Out to lunch since ${fmtTime(entry.lunch_out)}` };
+  if (entry.lunch_in) return { key: 'back_from_lunch', label: `Clocked in from lunch at ${fmtTime(entry.lunch_in)}` };
+  return { key: 'clocked_in', label: `Clocked in at ${fmtTime(entry.clock_in)}` };
+}
+
+function fmtTime(v) {
+  if (!v) return '—';
+  return new Date(v).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function fmtDateTime(v) {
+  if (!v) return '—';
+  return new Date(v).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}

--- a/screens/settings-user-edit.html
+++ b/screens/settings-user-edit.html
@@ -28,6 +28,7 @@
         <label><input type="checkbox" id="can_drop_off_form"> Drop Off Form</label>
         <label><input type="checkbox" id="can_estimates_buy_tickets"> Estimates/Buy Tickets</label>
         <label><input type="checkbox" id="can_timekeeping"> Timekeeping</label>
+        <label><input type="checkbox" id="clockin_required"> Clock-in Required</label>
         <label><input type="checkbox" id="can_settings"> Settings</label>
       </div>
     </fieldset>

--- a/screens/settings-user-edit.js
+++ b/screens/settings-user-edit.js
@@ -27,7 +27,7 @@ async function load(){
   $('role').value = u.role || 'clerk';
 
   ['can_pos','can_cash_drawer','can_cash_payouts','can_item_research','can_inventory',
-   'can_inventory_intake','can_drop_off_form','can_estimates_buy_tickets','can_timekeeping','can_settings',
+   'can_inventory_intake','can_drop_off_form','can_estimates_buy_tickets','can_timekeeping','clockin_required','can_settings',
    'notify_cash_drawer','notify_daily_sales_summary'].forEach(k => { $(k).checked = !!u[k]; });
 
   $('discount_max').value = (u.discount_max ?? '');
@@ -51,6 +51,8 @@ async function load(){
       $('save').disabled = false; $('save').textContent = 'Save';
     }
   };
+}
+
 function collect(){
   const user_id = $('user_id').value; // from hidden input set during prefill
   const name = $('name').value.trim();
@@ -78,6 +80,7 @@ function collect(){
       can_drop_off_form: $('can_drop_off_form').checked,
       can_estimates_buy_tickets: $('can_estimates_buy_tickets').checked,
       can_timekeeping: $('can_timekeeping').checked,
+      clockin_required: $('clockin_required').checked,
       can_settings: $('can_settings').checked
     },
     notifications: {

--- a/screens/settings-user-new.html
+++ b/screens/settings-user-new.html
@@ -30,6 +30,7 @@
         <label><input type="checkbox" id="can_drop_off_form"> Drop Off Form</label>
         <label><input type="checkbox" id="can_estimates_buy_tickets"> Estimates/Buy Tickets</label>
         <label><input type="checkbox" id="can_timekeeping" checked> Timekeeping</label>
+        <label><input type="checkbox" id="clockin_required"> Clock-in Required</label>
         <label><input type="checkbox" id="can_settings"> Settings</label>
       </div>
     </fieldset>

--- a/screens/settings-user-new.js
+++ b/screens/settings-user-new.js
@@ -64,6 +64,7 @@ function collect(){
       can_drop_off_form: $('can_drop_off_form').checked,
       can_estimates_buy_tickets: $('can_estimates_buy_tickets').checked,
       can_timekeeping: $('can_timekeeping').checked,
+      clockin_required: $('clockin_required').checked,
       can_settings: $('can_settings').checked
     },
     notifications: {


### PR DESCRIPTION
### Motivation

- Introduce a `clockin_required` permission to allow tenants to require employees to clock in, and surface that state in the UI and server flows.

### Description

- Persist `clockin_required` in permission upserts and selects by updating `functions/api/settings/users/create.ts` and `functions/api/settings/users/list.ts` to include the field in `INSERT`/`ON CONFLICT` and `SELECT` queries.
- Expose the flag in timesheet actor resolution by adding `clockin_required` to `functions/api/timesheet/_helpers.ts` so timesheet endpoints can enforce or display the requirement.
- Add a new admin timesheet summary endpoint `functions/api/timesheet/admin-status.ts` that returns per-user today’s time entry snapshot plus a human-friendly status label for managers/admins with edit permission.
- Add dashboard UI to show personal timekeeping status and team status: new/updated files `screens/dashboard.html` and `screens/dashboard.js` implement personal status, clock-in button, last clock out, and a team table for authorized users.
- Add `Clock-in Required` checkbox to user create/edit screens and wire it into payloads by updating `screens/settings-user-new.html`, `screens/settings-user-new.js`, `screens/settings-user-edit.html`, and `screens/settings-user-edit.js` to include `clockin_required` in forms and collected `permissions`.

### Testing

- Ran project build with `npm run build` and TypeScript checks which completed successfully. 
- Ran the automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a29b59f4833195fdd1ed343c243d)