### PR TITLE
timesheet: enforce active users and clockin_required, prevent duplicate clock-ins, and update dashboard prompts

### DIFF
--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -60,6 +60,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
   const rows = await sql<{
     role: string;
     active: boolean;
+    user_is_active: boolean;
     can_timekeeping: boolean;
     can_edit_timesheet: boolean;
     clockin_required: boolean;
@@ -69,6 +70,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
     SELECT
       m.role,
       m.active,
+      COALESCE(u.is_active, false) AS user_is_active,
       COALESCE(p.can_timekeeping, false) AS can_timekeeping,
       COALESCE(p.can_edit_timesheet, false) AS can_edit_timesheet,
       COALESCE(p.clockin_required, false) AS clockin_required,
@@ -81,7 +83,9 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
     LIMIT 1
   `;
 
-  if (!rows.length || rows[0].active === false) return { error: json({ ok: false, error: 'forbidden' }, 403) };
+  if (!rows.length || rows[0].active === false || rows[0].user_is_active === false) {
+    return { error: json({ ok: false, error: 'forbidden' }, 403) };
+  }
   if (!rows[0].can_timekeeping) return { error: json({ ok: false, error: 'timesheet_denied' }, 403) };
 
   return {

--- a/functions/api/timesheet/admin-status.ts
+++ b/functions/api/timesheet/admin-status.ts
@@ -18,8 +18,11 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
         SELECT u.user_id, u.name, u.login_id
         FROM app.memberships m
         JOIN app.users u ON u.user_id = m.user_id
+        JOIN app.permissions p ON p.user_id = m.user_id
         WHERE m.tenant_id = ${actor.tenant_id}
           AND m.active = true
+          AND u.is_active IS TRUE
+          AND COALESCE(p.clockin_required, false) = true
       ),
       latest_today AS (
         SELECT DISTINCT ON (te.login_id)

--- a/functions/api/timesheet/punch.ts
+++ b/functions/api/timesheet/punch.ts
@@ -31,8 +31,9 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const existing = existingRows[0] || null;
 
     if (!existing && action !== 'clock_in') return json({ ok: false, error: 'clock_in_required' }, 400);
+    if (existing && action === 'clock_in' && !existing.clock_out) return json({ ok: false, error: 'already_punched' }, 400);
 
-    if (!existing && action === 'clock_in') {
+    if (action === 'clock_in' && (!existing || !!existing.clock_out)) {
       const entry_id = makeEntryId();
       const totalHours = computeTotalHours({ clock_in: nowIso, clock_out: null, lunch_out: null, lunch_in: null });
       await sql/*sql*/`

--- a/screens/dashboard.js
+++ b/screens/dashboard.js
@@ -73,7 +73,11 @@ async function loadTeamStatus() {
 }
 
 async function onClockIn() {
-  if (state.todayEntry?.clock_in) return;
+  const status = deriveStatus(state.todayEntry);
+  if (status.key === 'clocked_in' || status.key === 'back_from_lunch') {
+    showToast('You are already clocked in.');
+    return;
+  }
   try {
     const res = await api('/api/timesheet/punch', {
       method: 'POST',
@@ -91,7 +95,7 @@ async function onClockIn() {
 function renderMyStatus() {
   const entry = state.todayEntry;
   const status = deriveStatus(entry);
-  const needsPrompt = !!state.actor?.clockin_required && !entry?.clock_in;
+  const needsPrompt = !!state.actor?.clockin_required && ['not_clocked_in', 'clocked_out', 'lunch_out'].includes(status.key);
 
   if (els.myStatusLine) els.myStatusLine.textContent = `Current status: ${status.label}`;
   if (els.dashIntro) {
@@ -101,7 +105,10 @@ function renderMyStatus() {
   }
 
   if (els.myPrompt) els.myPrompt.style.display = needsPrompt ? '' : 'none';
-  if (els.btnDashboardClockIn) els.btnDashboardClockIn.disabled = !!entry?.clock_in;
+  if (els.btnDashboardClockIn) {
+    const canQuickClockIn = ['not_clocked_in', 'clocked_out', 'lunch_out'].includes(status.key);
+    els.btnDashboardClockIn.disabled = !canQuickClockIn;
+  }
 
   const lastClockOut = getLastClockOut();
   if (els.myLastClockOut) {


### PR DESCRIPTION
### Motivation

- Ensure timesheet APIs only allow active users and users with clock-in required permission to be visible in admin views and to act on timesheets.
- Prevent accidental or duplicate `clock_in` entries when an open entry without `clock_out` already exists.
- Improve dashboard UX so the clock-in prompt and button state reflect derived status instead of raw presence of `clock_in`.

### Description

- Added `user_is_active` to the actor membership query in `functions/api/timesheet/_helpers.ts` and deny access when the linked user is inactive by returning a 403 error.  
- Updated `functions/api/timesheet/admin-status.ts` to join `app.permissions`, require `u.is_active IS TRUE`, and only include users with `COALESCE(p.clockin_required, false) = true` in the tenant users CTE.  
- Hardened `functions/api/timesheet/punch.ts` to reject a `clock_in` when there is an existing open entry without `clock_out`, and simplified the insertion condition to only create a new entry when appropriate.  
- Updated `screens/dashboard.js` to derive status with `deriveStatus(state.todayEntry)` and use the status key to control the clock-in prompt, quick clock-in availability, button disabled state, and show a toast when attempting to clock in while already clocked in.

### Testing

- Ran the server-side unit test suite and the API integration tests; all tests passed.  
- Ran the frontend automated UI/test runner against the dashboard flows; clock-in related checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ac3785348331b79510cd3521c677)