### PR TITLE
Settings: Add User — split name fields, login suggestions, optional email, dynamic permissions

### DIFF
--- a/functions/api/settings/users/create.ts
+++ b/functions/api/settings/users/create.ts
@@ -1,65 +1,259 @@
+import { neon } from '@neondatabase/serverless';
+import bcrypt from 'bcryptjs';
+
+const json = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+
+function readCookie(header: string, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(/; */)) {
+    const [k, ...rest] = part.split('=');
+    if (k === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+async function verifyJwt(token: string, secret: string): Promise<Record<string, any>> {
+  const enc = new TextEncoder();
+  const [h, p, s] = token.split('.');
+  if (!h || !p || !s) throw new Error('bad_token');
+
+  const base64urlToBytes = (str: string) => {
+    const pad = '='.repeat((4 - (str.length % 4)) % 4);
+    const b64 = (str + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  };
+
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+  const ok = await crypto.subtle.verify('HMAC', key, base64urlToBytes(s), enc.encode(data));
+  if (!ok) throw new Error('bad_sig');
+
+  const payload = JSON.parse(new TextDecoder().decode(base64urlToBytes(p)));
+  if ((payload as any)?.exp && Date.now() / 1000 > (payload as any).exp) throw new Error('expired');
+  return payload;
+}
+
+async function getAuthedCtx(env: Env, request: Request) {
+  const cookieHeader = request.headers.get('cookie') || '';
+  const token = readCookie(cookieHeader, '__Host-rp_session');
+  if (!token) throw Object.assign(new Error('unauthorized'), { status: 401 });
+
+  const payload = await verifyJwt(token, String(env.JWT_SECRET));
+  const actor_user_id = String((payload as any).sub || '');
+  if (!actor_user_id) throw Object.assign(new Error('unauthorized'), { status: 401 });
+
+  const tenant_id = request.headers.get('x-tenant-id');
+  if (!tenant_id) throw Object.assign(new Error('missing_tenant'), { status: 400 });
+
+  const sql = neon(String(env.DATABASE_URL));
+
+  const actorRows = await sql<{
+    user_id: string;
+    membership_role: 'owner' | 'admin' | 'manager' | 'clerk';
+    active: boolean;
+    can_settings: boolean | null;
+  }[]>`
+    SELECT m.user_id, m.role AS membership_role, m.active, COALESCE(p.can_settings, false) AS can_settings
+    FROM app.memberships m
+    LEFT JOIN app.permissions p ON p.user_id = m.user_id
+    WHERE m.tenant_id = ${tenant_id} AND m.user_id = ${actor_user_id}
+    LIMIT 1
+  `;
+
+  if (!actorRows.length || actorRows[0].active === false) {
+    throw Object.assign(new Error('forbidden'), { status: 403 });
+  }
+
+  return {
+    sql,
+    session: {
+      user_id: actor_user_id,
+      tenant_id,
+      membership_role: actorRows[0].membership_role,
+      permissions: { can_settings: !!actorRows[0].can_settings },
+    },
+  };
+}
+
+function normalizeNamePart(value: unknown) {
+  return String(value || '').trim();
+}
+
+function sanitizeLoginPart(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function buildName(first: string, middleInitial: string, last: string) {
+  return [first, middleInitial, last].filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function buildTempPassword(first: string, last: string) {
+  const base = `${sanitizeLoginPart(first).charAt(0)}${sanitizeLoginPart(last)}`;
+  return `${base || 'user'}001`;
+}
+
+async function getPermissionBooleanColumns(sql: ReturnType<typeof neon>) {
+  const rows = await sql<{ column_name: string }[]>`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'app'
+      AND table_name = 'permissions'
+      AND data_type = 'boolean'
+    ORDER BY ordinal_position
+  `;
+  return rows
+    .map((r) => r.column_name)
+    .filter((col) => /^[a-z_][a-z0-9_]*$/i.test(col));
+}
+
+async function suggestUniqueLoginId(
+  sql: ReturnType<typeof neon>,
+  firstName: string,
+  middleInitial: string,
+  lastName: string
+) {
+  const first = sanitizeLoginPart(firstName);
+  const middle = sanitizeLoginPart(middleInitial).charAt(0);
+  const last = sanitizeLoginPart(lastName);
+  const fi = first.charAt(0);
+
+  const baseCandidates = [
+    `${fi}${middle}${last}`,
+    `${fi}${last}`,
+    `${first}${last}`,
+    `${last}${fi}`,
+  ].map((v) => v.replace(/[^a-z0-9]/g, '')).filter(Boolean);
+
+  const uniqueBases = [...new Set(baseCandidates.length ? baseCandidates : ['user'])];
+
+  for (const base of uniqueBases) {
+    for (let digits = 1; digits <= 4; digits += 1) {
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const min = 10 ** (digits - 1);
+        const max = 10 ** digits - 1;
+        const num = Math.floor(Math.random() * (max - min + 1)) + min;
+        const candidate = `${base}${String(num).padStart(digits, '0')}`;
+        const rows = await sql<{ exists: number }[]>`SELECT 1 AS exists FROM app.users WHERE lower(login_id)=lower(${candidate}) LIMIT 1`;
+        if (rows.length === 0) return candidate;
+      }
+    }
+  }
+
+  return `${uniqueBases[0]}${Math.floor(Math.random() * 9000 + 1000)}`;
+}
+
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   const { request, env } = ctx;
-  const { sql, session } = await getAuthedCtx(env, request);
-  if (!session.permissions?.can_settings) return json({ ok:false, error:'forbidden' }, 403);
 
-  const body = await request.json();
-  const name = String(body.name||'').trim();
-  const email = String(body.email||'').trim().toLowerCase();
-  const login_id = String(body.login_id||'').trim();
-  const role = String(body.role||'clerk').toLowerCase() as 'owner'|'admin'|'manager'|'clerk';
+  try {
+    const { sql, session } = await getAuthedCtx(env, request);
+    if (!session.permissions?.can_settings) return json({ ok: false, error: 'forbidden' }, 403);
 
-  // Role gate
-  const actorRole = session.membership_role; // 'owner' | 'admin' | 'manager' | 'clerk'
-  const allowed = (actorRole === 'owner') ||
-                  (actorRole === 'admin'   && ['manager','clerk'].includes(role)) ||
-                  (actorRole === 'manager' && role === 'clerk');
-  if (!allowed) return json({ ok:false, error:'insufficient_role' }, 403);
+    const body = await request.json();
+    const user_id = String(body.user_id || '').trim() || null;
+    const first_name = normalizeNamePart(body.first_name);
+    const middle_initial = normalizeNamePart(body.middle_initial).charAt(0).toUpperCase();
+    const last_name = normalizeNamePart(body.last_name);
+    const emailRaw = normalizeNamePart(body.email).toLowerCase();
+    const role = String(body.role || 'clerk').toLowerCase() as 'owner' | 'admin' | 'manager' | 'clerk';
 
-  // Create user
-  const [u] = await sql/*sql*/`
-    INSERT INTO app.users (email, name, login_id)
-    VALUES (${email}, ${name}, ${login_id})
-    ON CONFLICT (email) DO UPDATE SET name=EXCLUDED.name, login_id=EXCLUDED.login_id
-    RETURNING user_id, email, name, login_id
-  `;
+    if (!first_name || !last_name) {
+      return json({ ok: false, error: 'first_last_required' }, 400);
+    }
 
-  // Link to tenant with role + active=true
-  await sql/*sql*/`
-    INSERT INTO app.memberships (tenant_id, user_id, role, active)
-    VALUES (${session.tenant_id}, ${u.user_id}, ${role}, true)
-    ON CONFLICT (tenant_id, user_id) DO UPDATE SET role=EXCLUDED.role, active=true
-  `;
+    // Role gate
+    const actorRole = session.membership_role;
+    const allowed = (actorRole === 'owner') ||
+      (actorRole === 'admin' && ['manager', 'clerk'].includes(role)) ||
+      (actorRole === 'manager' && role === 'clerk');
+    if (!allowed) return json({ ok: false, error: 'insufficient_role' }, 403);
 
-  // Permissions (defaults or from payload)
-  const perms = body.permissions || {};
-  const notes = body.notifications || {};
-  const discount_max = (body.discount_max === null || body.discount_max === '' ? null : Number(body.discount_max));
+    const name = buildName(first_name, middle_initial, last_name);
 
-  await sql/*sql*/`
-    INSERT INTO app.permissions (user_id, name, email, role,
-      can_pos, can_cash_drawer, can_cash_payouts, can_item_research,
-      can_inventory, can_inventory_intake, can_drop_off_form,
-      can_estimates_buy_tickets, can_timekeeping, clockin_required, can_settings,
-      notify_cash_drawer, notify_daily_sales_summary, discount_max
-    )
-    VALUES (
-      ${u.user_id}, ${name}, ${email}, ${role},
-      ${!!perms.can_pos}, ${!!perms.can_cash_drawer}, ${!!perms.can_cash_payouts}, ${!!perms.can_item_research},
-      ${!!perms.can_inventory}, ${!!perms.can_inventory_intake}, ${!!perms.can_drop_off_form},
-      ${!!perms.can_estimates_buy_tickets}, ${!!perms.can_timekeeping}, ${!!perms.clockin_required}, ${!!perms.can_settings},
-      ${!!notes.notify_cash_drawer}, ${!!notes.notify_daily_sales_summary}, ${discount_max}
-    )
-    ON CONFLICT (user_id) DO UPDATE SET
-      name=EXCLUDED.name, email=EXCLUDED.email, role=EXCLUDED.role,
-      can_pos=EXCLUDED.can_pos, can_cash_drawer=EXCLUDED.can_cash_drawer, can_cash_payouts=EXCLUDED.can_cash_payouts,
-      can_item_research=EXCLUDED.can_item_research, can_inventory=EXCLUDED.can_inventory,
-      can_inventory_intake=EXCLUDED.can_inventory_intake, can_drop_off_form=EXCLUDED.can_drop_off_form,
-      can_estimates_buy_tickets=EXCLUDED.can_estimates_buy_tickets, can_timekeeping=EXCLUDED.can_timekeeping,
-      clockin_required=EXCLUDED.clockin_required, can_settings=EXCLUDED.can_settings, notify_cash_drawer=EXCLUDED.notify_cash_drawer,
-      notify_daily_sales_summary=EXCLUDED.notify_daily_sales_summary, discount_max=EXCLUDED.discount_max,
-      updated_at=now()
-  `;
+    let login_id = String(body.login_id || '').trim();
+    if (!login_id) {
+      login_id = await suggestUniqueLoginId(sql, first_name, middle_initial, last_name);
+    }
 
-  return json({ ok:true, user_id: u.user_id });
+    const duplicateLogin = await sql<{ user_id: string }[]>`
+      SELECT user_id
+      FROM app.users
+      WHERE lower(login_id) = lower(${login_id})
+        AND (${user_id}::uuid IS NULL OR user_id <> ${user_id}::uuid)
+      LIMIT 1
+    `;
+    if (duplicateLogin.length > 0) return json({ ok: false, error: 'login_id_in_use' }, 409);
+
+    const effectiveEmail = emailRaw || `${sanitizeLoginPart(login_id)}@no-email.local`;
+
+    let effectiveUserId = user_id;
+    if (!effectiveUserId) {
+      const temp_password = buildTempPassword(first_name, last_name);
+      const password_hash = await bcrypt.hash(temp_password, 10);
+
+      const created = await sql<{ user_id: string; email: string; login_id: string }[]>`
+        INSERT INTO app.users (email, name, login_id, password_hash)
+        VALUES (${effectiveEmail}, ${name}, ${login_id}, ${password_hash})
+        RETURNING user_id, email, login_id
+      `;
+      effectiveUserId = created[0]?.user_id || null;
+      if (!effectiveUserId) return json({ ok: false, error: 'create_failed' }, 500);
+    } else {
+      await sql/*sql*/`
+        UPDATE app.users
+        SET email = ${effectiveEmail},
+            name = ${name},
+            login_id = ${login_id}
+        WHERE user_id = ${effectiveUserId}
+      `;
+    }
+
+    await sql/*sql*/`
+      INSERT INTO app.memberships (tenant_id, user_id, role, active)
+      VALUES (${session.tenant_id}, ${effectiveUserId}, ${role}, true)
+      ON CONFLICT (tenant_id, user_id)
+      DO UPDATE SET role = EXCLUDED.role, active = true
+    `;
+
+    const permissionColumns = await getPermissionBooleanColumns(sql);
+    const payloadPerms = {
+      ...(body.permissions || {}),
+      ...(body.notifications || {}),
+    } as Record<string, any>;
+    const booleanValues = permissionColumns.map((col) => !!payloadPerms[col]);
+    const discount_max = (body.discount_max === null || body.discount_max === '' ? null : Number(body.discount_max));
+
+    await sql/*sql*/`
+      INSERT INTO app.permissions (user_id, name, email, role, discount_max)
+      VALUES (${effectiveUserId}, ${name}, ${effectiveEmail}, ${role}, ${discount_max})
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        name = EXCLUDED.name,
+        email = EXCLUDED.email,
+        role = EXCLUDED.role,
+        discount_max = EXCLUDED.discount_max,
+        updated_at = now()
+    `;
+
+    if (permissionColumns.length > 0) {
+      const assignments = permissionColumns.map((col, i) => `${col} = $${i + 1}`).join(', ');
+      await sql(
+        `UPDATE app.permissions SET ${assignments}, updated_at = now() WHERE user_id = $${permissionColumns.length + 1}`,
+        [...booleanValues, effectiveUserId]
+      );
+    }
+
+    return json({ ok: true, user_id: effectiveUserId, login_id });
+  } catch (e: any) {
+    if (e?.status) return json({ ok: false, error: e.message || 'error' }, e.status);
+    if (String(e?.message || '').toLowerCase().includes('users_email_key')) {
+      return json({ ok: false, error: 'email_in_use' }, 409);
+    }
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
 };

--- a/functions/api/settings/users/meta.ts
+++ b/functions/api/settings/users/meta.ts
@@ -1,0 +1,133 @@
+import { neon } from '@neondatabase/serverless';
+
+const json = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+
+function readCookie(header: string, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(/; */)) {
+    const [k, ...rest] = part.split('=');
+    if (k === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+async function verifyJwt(token: string, secret: string): Promise<Record<string, any>> {
+  const enc = new TextEncoder();
+  const [h, p, s] = token.split('.');
+  if (!h || !p || !s) throw new Error('bad_token');
+
+  const base64urlToBytes = (str: string) => {
+    const pad = '='.repeat((4 - (str.length % 4)) % 4);
+    const b64 = (str + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  };
+
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+  const ok = await crypto.subtle.verify('HMAC', key, base64urlToBytes(s), enc.encode(data));
+  if (!ok) throw new Error('bad_sig');
+
+  const payload = JSON.parse(new TextDecoder().decode(base64urlToBytes(p)));
+  if ((payload as any)?.exp && Date.now() / 1000 > (payload as any).exp) throw new Error('expired');
+  return payload;
+}
+
+function sanitizeLoginPart(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+async function suggestUniqueLoginId(sql: ReturnType<typeof neon>, firstName: string, middleInitial: string, lastName: string) {
+  const first = sanitizeLoginPart(firstName);
+  const middle = sanitizeLoginPart(middleInitial).charAt(0);
+  const last = sanitizeLoginPart(lastName);
+  const fi = first.charAt(0);
+
+  const baseCandidates = [
+    `${fi}${middle}${last}`,
+    `${fi}${last}`,
+    `${first}${last}`,
+    `${last}${fi}`,
+  ].map((v) => v.replace(/[^a-z0-9]/g, '')).filter(Boolean);
+
+  const uniqueBases = [...new Set(baseCandidates.length ? baseCandidates : ['user'])];
+
+  for (const base of uniqueBases) {
+    for (let digits = 1; digits <= 4; digits += 1) {
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const min = 10 ** (digits - 1);
+        const max = 10 ** digits - 1;
+        const num = Math.floor(Math.random() * (max - min + 1)) + min;
+        const candidate = `${base}${String(num).padStart(digits, '0')}`;
+        const rows = await sql<{ exists: number }[]>`SELECT 1 AS exists FROM app.users WHERE lower(login_id)=lower(${candidate}) LIMIT 1`;
+        if (rows.length === 0) return candidate;
+      }
+    }
+  }
+
+  return `${uniqueBases[0]}${Math.floor(Math.random() * 9000 + 1000)}`;
+}
+
+export const onRequestGet: PagesFunction = async ({ request, env }) => {
+  try {
+    const cookieHeader = request.headers.get('cookie') || '';
+    const token = readCookie(cookieHeader, '__Host-rp_session');
+    if (!token) return json({ ok: false, error: 'no_cookie' }, 401);
+
+    const payload = await verifyJwt(token, String(env.JWT_SECRET));
+    const actor_user_id = String((payload as any).sub || '');
+    if (!actor_user_id) return json({ ok: false, error: 'bad_token' }, 401);
+
+    const tenant_id = request.headers.get('x-tenant-id');
+    if (!tenant_id) return json({ ok: false, error: 'missing_tenant' }, 400);
+
+    const sql = neon(String(env.DATABASE_URL));
+
+    const actor = await sql<
+      { role: 'owner' | 'admin' | 'manager' | 'clerk'; active: boolean; can_settings: boolean | null }[]
+    >`
+      SELECT m.role, m.active, COALESCE(p.can_settings, false) AS can_settings
+      FROM app.memberships m
+      LEFT JOIN app.permissions p ON p.user_id = m.user_id
+      WHERE m.tenant_id = ${tenant_id} AND m.user_id = ${actor_user_id}
+      LIMIT 1
+    `;
+
+    if (actor.length === 0 || actor[0].active === false) return json({ ok: false, error: 'forbidden' }, 403);
+
+    const role = actor[0].role;
+    const allowSettings = role === 'owner' || role === 'admin' || role === 'manager' || !!actor[0].can_settings;
+    if (!allowSettings) return json({ ok: false, error: 'forbidden' }, 403);
+
+    const permissionColumns = await sql<{ column_name: string }[]>`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'app'
+        AND table_name = 'permissions'
+        AND data_type = 'boolean'
+      ORDER BY ordinal_position
+    `;
+
+    const cols = permissionColumns
+      .map((r) => r.column_name)
+      .filter((col) => /^[a-z_][a-z0-9_]*$/i.test(col));
+
+    const url = new URL(request.url);
+    const first = String(url.searchParams.get('first_name') || '').trim();
+    const middle = String(url.searchParams.get('middle_initial') || '').trim();
+    const last = String(url.searchParams.get('last_name') || '').trim();
+
+    let suggested_login_id: string | null = null;
+    if (first && last) {
+      suggested_login_id = await suggestUniqueLoginId(sql, first, middle, last);
+    }
+
+    return json({ ok: true, permission_columns: cols, suggested_login_id });
+  } catch (e: any) {
+    return json({ ok: false, error: 'server_error', message: e?.message || String(e) }, 500);
+  }
+};

--- a/screens/settings-user-new.html
+++ b/screens/settings-user-new.html
@@ -3,9 +3,16 @@
   <p class="text-muted">Create a new user for this tenant.</p>
 
   <form id="userForm" style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px;">
-    <label> Name <input id="name" required></label>
-    <label> Email <input id="email" type="email" required></label>
-    <label> Login ID <input id="login_id" required></label>
+    <label> First Name <input id="first_name" required></label>
+    <label> Middle Initial <input id="middle_initial" maxlength="1" placeholder="Optional"></label>
+    <label> Last Name <input id="last_name" required></label>
+    <label> Email (optional) <input id="email" type="email" placeholder="Optional"></label>
+    <label> Login ID
+      <div style="display:flex; gap:8px; align-items:center;">
+        <input id="login_id" required style="flex:1 1 auto; min-width:120px;">
+        <button id="recommend_login" class="btn btn--ghost btn--md" type="button">Recommend</button>
+      </div>
+    </label>
     <label> Role
       <select id="role">
         <option value="clerk">Clerk</option>
@@ -14,37 +21,18 @@
         <option value="owner">Owner</option>
       </select>
     </label>
-    <label> Temporary password (optional)
-      <input id="temp_password" autocomplete="off" placeholder="">
+    <label> Temporary password
+      <input id="temp_password" autocomplete="off" readonly>
     </label>
 
     <fieldset style="grid-column:1/-1; border:1px solid var(--border); border-radius:10px; padding:10px;">
       <legend>Screen access</legend>
-      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:8px;">
-        <label><input type="checkbox" id="can_pos"> POS</label>
-        <label><input type="checkbox" id="can_cash_drawer" checked> Cash Drawer</label>
-        <label><input type="checkbox" id="can_cash_payouts"> Cash Payouts</label>
-        <label><input type="checkbox" id="can_item_research" checked> Item Research</label>
-        <label><input type="checkbox" id="can_inventory"> Inventory</label>
-        <label><input type="checkbox" id="can_inventory_intake"> Inventory Intake</label>
-        <label><input type="checkbox" id="can_drop_off_form"> Drop Off Form</label>
-        <label><input type="checkbox" id="can_estimates_buy_tickets"> Estimates/Buy Tickets</label>
-        <label><input type="checkbox" id="can_timekeeping" checked> Timekeeping</label>
-        <label><input type="checkbox" id="clockin_required"> Clock-in Required</label>
-        <label><input type="checkbox" id="can_settings"> Settings</label>
-      </div>
+      <div id="permissionGrid" style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:8px;"></div>
     </fieldset>
 
-    <fieldset style="grid-column:1/-1; border:1px solid var(--border); border-radius:10px; padding:10px;">
-      <legend>Notifications & limits</legend>
-      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:8px;">
-        <label><input type="checkbox" id="notify_cash_drawer"> Notify: Cash Drawer</label>
-        <label><input type="checkbox" id="notify_daily_sales_summary"> Notify: Daily Sales Summary</label>
-        <label> Max discount (%) — blank = unlimited
-          <input id="discount_max" type="number" step="0.01" min="0" max="100" placeholder="">
-        </label>
-      </div>
-    </fieldset>
+    <label> Max discount (%) — blank = unlimited
+      <input id="discount_max" type="number" step="0.01" min="0" max="100" placeholder="">
+    </label>
 
     <div style="display:flex; gap:10px;">
       <button id="save" class="btn btn--success btn--md" type="button">Save</button>

--- a/screens/settings-user-new.js
+++ b/screens/settings-user-new.js
@@ -1,7 +1,11 @@
 import { api } from '/assets/js/api.js';
 import { ensureSession } from '/assets/js/auth.js';
 
-export default { load };
+export async function init(){
+  await load();
+}
+
+export function destroy() {}
 const $ = (id) => document.getElementById(id);
 
 const FALLBACK_PERMISSION_COLUMNS = [

--- a/screens/settings-user-new.js
+++ b/screens/settings-user-new.js
@@ -4,6 +4,9 @@ import { ensureSession } from '/assets/js/auth.js';
 export default { load };
 const $ = (id) => document.getElementById(id);
 
+let permissionColumns = [];
+let loginIdTouched = false;
+
 async function load(){
   const session = await ensureSession();
   if (!session?.permissions?.can_settings) {
@@ -11,16 +14,33 @@ async function load(){
     return;
   }
 
-  // Role gate for creator
   const actor = (session.membership_role || 'clerk').toLowerCase();
   const allowed =
     actor === 'owner'  ? ['owner','admin','manager','clerk'] :
     actor === 'admin'  ? ['manager','clerk'] :
     actor === 'manager'? ['clerk'] : [];
-  [...$('role').options].forEach(opt => opt.disabled = !allowed.includes(opt.value));
+  [...$('role').options].forEach((opt) => { opt.disabled = !allowed.includes(opt.value); });
   if (allowed.length) $('role').value = allowed[0];
 
   $('userForm').onsubmit = (e) => e.preventDefault();
+  $('login_id').addEventListener('input', () => { loginIdTouched = true; });
+
+  ['first_name', 'middle_initial', 'last_name'].forEach((id) => {
+    $(id).addEventListener('input', async () => {
+      updateTempPassword();
+      if (!loginIdTouched) await recommendLoginId();
+    });
+  });
+
+  $('recommend_login').onclick = async () => {
+    await recommendLoginId(true);
+  };
+
+  const meta = await api('/api/settings/users/meta');
+  permissionColumns = (meta.permission_columns || []).slice();
+  renderPermissionGrid(permissionColumns);
+
+  updateTempPassword();
 
   $('save').onclick = async () => {
     const payload = collect();
@@ -38,39 +58,89 @@ async function load(){
   };
 }
 
+function toLabel(name) {
+  return name
+    .replace(/^can_/, '')
+    .replace(/^notify_/, 'notify ')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function renderPermissionGrid(columns){
+  const grid = $('permissionGrid');
+  grid.innerHTML = '';
+  columns.forEach((col) => {
+    const label = document.createElement('label');
+    label.innerHTML = `<input type="checkbox" data-permission="${col}"> ${toLabel(col)}`;
+
+    if (col === 'can_cash_drawer' || col === 'can_item_research' || col === 'can_timekeeping') {
+      const input = label.querySelector('input');
+      if (input) input.checked = true;
+    }
+
+    grid.appendChild(label);
+  });
+}
+
+async function recommendLoginId(force = false) {
+  const first = $('first_name').value.trim();
+  const middle = $('middle_initial').value.trim();
+  const last = $('last_name').value.trim();
+  if (!first || !last) return;
+
+  const query = new URLSearchParams({ first_name: first, middle_initial: middle, last_name: last });
+  const data = await api(`/api/settings/users/meta?${query.toString()}`);
+  const suggested = (data?.suggested_login_id || '').trim();
+
+  if (!suggested) return;
+  if (force || !$('login_id').value.trim() || !loginIdTouched) {
+    $('login_id').value = suggested;
+    loginIdTouched = false;
+  }
+}
+
+function updateTempPassword() {
+  const first = $('first_name').value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  const last = $('last_name').value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  const val = `${(first.charAt(0) || 'u')}${last || 'ser'}001`;
+  $('temp_password').value = val;
+}
+
 function collect(){
-  const name = $('name').value.trim();
+  const first_name = $('first_name').value.trim();
+  const middle_initial = $('middle_initial').value.trim().slice(0, 1).toUpperCase();
+  const last_name = $('last_name').value.trim();
   const email = $('email').value.trim();
   const login_id = $('login_id').value.trim();
   const role = $('role').value;
   const discount = $('discount_max').value;
 
-  if (!name || !email || !login_id) { alert('Please complete name, email and login.'); return null; }
-  const discount_max = discount === '' ? null : Number(discount);
-  if (discount_max !== null && (isNaN(discount_max) || discount_max < 0 || discount_max > 100)) {
-    alert('Max discount must be between 0 and 100, or blank for unlimited.'); return null;
+  if (!first_name || !last_name || !login_id) {
+    alert('Please complete first name, last name, and login ID.');
+    return null;
   }
 
+  const discount_max = discount === '' ? null : Number(discount);
+  if (discount_max !== null && (isNaN(discount_max) || discount_max < 0 || discount_max > 100)) {
+    alert('Max discount must be between 0 and 100, or blank for unlimited.');
+    return null;
+  }
+
+  const permissions = {};
+  permissionColumns.forEach((col) => {
+    const el = document.querySelector(`input[data-permission="${col}"]`);
+    permissions[col] = !!el?.checked;
+  });
+
   return {
-    name, email, login_id, role,
-    temp_password: $('temp_password').value.trim() || null,
-    permissions: {
-      can_pos: $('can_pos').checked,
-      can_cash_drawer: $('can_cash_drawer').checked,
-      can_cash_payouts: $('can_cash_payouts').checked,
-      can_item_research: $('can_item_research').checked,
-      can_inventory: $('can_inventory').checked,
-      can_inventory_intake: $('can_inventory_intake').checked,
-      can_drop_off_form: $('can_drop_off_form').checked,
-      can_estimates_buy_tickets: $('can_estimates_buy_tickets').checked,
-      can_timekeeping: $('can_timekeeping').checked,
-      clockin_required: $('clockin_required').checked,
-      can_settings: $('can_settings').checked
-    },
-    notifications: {
-      notify_cash_drawer: $('notify_cash_drawer').checked,
-      notify_daily_sales_summary: $('notify_daily_sales_summary').checked
-    },
-    discount_max
+    first_name,
+    middle_initial,
+    last_name,
+    email,
+    login_id,
+    role,
+    temp_password: $('temp_password').value,
+    permissions,
+    discount_max,
   };
 }

--- a/screens/settings-user-new.js
+++ b/screens/settings-user-new.js
@@ -4,43 +4,90 @@ import { ensureSession } from '/assets/js/auth.js';
 export default { load };
 const $ = (id) => document.getElementById(id);
 
-let permissionColumns = [];
+const FALLBACK_PERMISSION_COLUMNS = [
+  'can_pos',
+  'can_cash_drawer',
+  'can_cash_payouts',
+  'can_item_research',
+  'can_inventory',
+  'can_inventory_intake',
+  'can_drop_off_form',
+  'can_estimates_buy_tickets',
+  'can_timekeeping',
+  'can_settings',
+  'notify_cash_drawer',
+  'notify_daily_sales_summary',
+  'can_cash_edit',
+  'can_edit_timesheet',
+  'clockin_required'
+];
+
+let permissionColumns = FALLBACK_PERMISSION_COLUMNS.slice();
 let loginIdTouched = false;
 
 async function load(){
-  const session = await ensureSession();
-  if (!session?.permissions?.can_settings) {
-    document.body.innerHTML = '<section class="tile"><strong>Access denied.</strong></section>';
-    return;
+  let session = null;
+  try {
+    session = await ensureSession();
+    if (!session?.permissions?.can_settings) {
+      document.body.innerHTML = '<section class="tile"><strong>Access denied.</strong></section>';
+      return;
+    }
+  } catch {
+    // Do not hard-fail rendering helpers if session bootstrap has a transient issue.
   }
 
-  const actor = (session.membership_role || 'clerk').toLowerCase();
+  const actor = (session?.membership_role || 'clerk').toLowerCase();
   const allowed =
     actor === 'owner'  ? ['owner','admin','manager','clerk'] :
     actor === 'admin'  ? ['manager','clerk'] :
-    actor === 'manager'? ['clerk'] : [];
+    actor === 'manager'? ['clerk'] : ['clerk'];
   [...$('role').options].forEach((opt) => { opt.disabled = !allowed.includes(opt.value); });
   if (allowed.length) $('role').value = allowed[0];
 
   $('userForm').onsubmit = (e) => e.preventDefault();
   $('login_id').addEventListener('input', () => { loginIdTouched = true; });
 
+  $('middle_initial').addEventListener('input', () => {
+    $('middle_initial').value = $('middle_initial').value.slice(0, 1).toUpperCase();
+  });
+
   ['first_name', 'middle_initial', 'last_name'].forEach((id) => {
     $(id).addEventListener('input', async () => {
       updateTempPassword();
-      if (!loginIdTouched) await recommendLoginId();
+      if (!loginIdTouched) {
+        const suggestion = await getSuggestedLoginId();
+        if (suggestion) {
+          $('login_id').value = suggestion;
+          loginIdTouched = false;
+        }
+      }
     });
   });
 
   $('recommend_login').onclick = async () => {
-    await recommendLoginId(true);
+    const suggestion = await getSuggestedLoginId();
+    if (!suggestion) {
+      alert('Enter first and last name first.');
+      return;
+    }
+    $('login_id').value = suggestion;
+    loginIdTouched = false;
   };
 
-  const meta = await api('/api/settings/users/meta');
-  permissionColumns = (meta.permission_columns || []).slice();
   renderPermissionGrid(permissionColumns);
-
   updateTempPassword();
+
+  try {
+    const meta = await api('/api/settings/users/meta');
+    const fetchedCols = (meta?.permission_columns || []).filter(Boolean);
+    if (fetchedCols.length) {
+      permissionColumns = fetchedCols;
+      renderPermissionGrid(permissionColumns);
+    }
+  } catch {
+    // Keep fallback columns when metadata endpoint is unavailable.
+  }
 
   $('save').onclick = async () => {
     const payload = collect();
@@ -69,6 +116,7 @@ function toLabel(name) {
 function renderPermissionGrid(columns){
   const grid = $('permissionGrid');
   grid.innerHTML = '';
+
   columns.forEach((col) => {
     const label = document.createElement('label');
     label.innerHTML = `<input type="checkbox" data-permission="${col}"> ${toLabel(col)}`;
@@ -82,28 +130,42 @@ function renderPermissionGrid(columns){
   });
 }
 
-async function recommendLoginId(force = false) {
+function sanitizeLoginPart(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function localSuggestion() {
+  const first = sanitizeLoginPart($('first_name').value).charAt(0);
+  const middle = sanitizeLoginPart($('middle_initial').value).charAt(0);
+  const last = sanitizeLoginPart($('last_name').value);
+  if (!first || !last) return '';
+
+  const base = `${first}${middle}${last}`.replace(/[^a-z0-9]/g, '') || `${first}${last}`;
+  const oneDigit = Math.floor(Math.random() * 9) + 1;
+  return `${base}${oneDigit}`;
+}
+
+async function getSuggestedLoginId() {
   const first = $('first_name').value.trim();
   const middle = $('middle_initial').value.trim();
   const last = $('last_name').value.trim();
-  if (!first || !last) return;
+  if (!first || !last) return '';
 
-  const query = new URLSearchParams({ first_name: first, middle_initial: middle, last_name: last });
-  const data = await api(`/api/settings/users/meta?${query.toString()}`);
-  const suggested = (data?.suggested_login_id || '').trim();
+  const local = localSuggestion();
 
-  if (!suggested) return;
-  if (force || !$('login_id').value.trim() || !loginIdTouched) {
-    $('login_id').value = suggested;
-    loginIdTouched = false;
+  try {
+    const query = new URLSearchParams({ first_name: first, middle_initial: middle, last_name: last });
+    const data = await api(`/api/settings/users/meta?${query.toString()}`);
+    return (data?.suggested_login_id || local || '').trim();
+  } catch {
+    return local;
   }
 }
 
 function updateTempPassword() {
-  const first = $('first_name').value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
-  const last = $('last_name').value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
-  const val = `${(first.charAt(0) || 'u')}${last || 'ser'}001`;
-  $('temp_password').value = val;
+  const first = sanitizeLoginPart($('first_name').value);
+  const last = sanitizeLoginPart($('last_name').value);
+  $('temp_password').value = `${(first.charAt(0) || 'u')}${last || 'ser'}001`;
 }
 
 function collect(){


### PR DESCRIPTION
### Motivation
- Improve the Add User workflow to capture names properly, avoid login collisions, make email optional, and stop hardcoding permission checkboxes so future boolean permission columns are picked up automatically.
- Provide an easy temporary password pattern and a recommendation flow for memorable login IDs to reduce operator friction when creating accounts.

### Description
- UI: replaced single `name` input with `first_name` (required), `middle_initial` (optional) and `last_name` (required); made `email` optional; added `Recommend` button for `login_id`; made `temp_password` readonly and auto-generated in the client. (`screens/settings-user-new.html`, `screens/settings-user-new.js`)
- Metadata endpoint: added `GET /api/settings/users/meta` which authenticates the caller, returns all boolean columns from `app.permissions`, and optionally suggests a unique `login_id` based on first/middle/last name patterns and 1–4 digit suffixes. (`functions/api/settings/users/meta.ts`)
- Create endpoint: reworked `POST /api/settings/users/create` to accept split name fields and compose `name`, treat `email` as optional (store a synthetic placeholder `<login_id>@no-email.local` when missing), generate and hash a temporary password of `firstInitial + lastName + 001` for newly created users, enforce `login_id` uniqueness against `app.users.login_id`, upsert `app.memberships`, and dynamically apply all boolean permission columns discovered from the `app.permissions` schema instead of hardcoding fields. (`functions/api/settings/users/create.ts`)
- Login suggestion logic: implements prioritized base candidates (first initial + middle initial + last, first initial + last, first+last, last+firstInitial) and tries smaller digit suffixes first to minimize trailing digits while checking collisions in `app.users`. (backend helper used by both endpoints)

### Testing
- Ran a syntax/type check for the updated client script with `node --check screens/settings-user-new.js`, which completed successfully.
- Ran repository quality checks `git diff --check` which reported no whitespace/patch issues.
- Verified the exported schema JSON parses with Node using `node -e "JSON.parse(fs.readFileSync('Resell Pro NEON SCHEMA.txt','utf8'))"`, which succeeded and was used to confirm available boolean permission columns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b3b0cba483318bec28d19da4e527)