### PR TITLE
Add manager cash movement reporting (daily/weekly/custom) to Drawer screen and API

### DIFF
--- a/functions/api/cash-report/summary.ts
+++ b/functions/api/cash-report/summary.ts
@@ -1,0 +1,287 @@
+import { neon } from "@neondatabase/serverless";
+
+const json = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+function readCookie(header: string, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(/; */)) {
+    const [k, ...rest] = part.split("=");
+    if (k === name) return decodeURIComponent(rest.join("="));
+  }
+  return null;
+}
+
+async function verifyJwt(token: string, secret: string): Promise<any> {
+  const enc = new TextEncoder();
+  const [h, p, s] = token.split(".");
+  if (!h || !p || !s) throw new Error("bad_token");
+
+  const base64urlToBytes = (str: string) => {
+    const pad = "=".repeat((4 - (str.length % 4)) % 4);
+    const b64 = (str + pad).replace(/-/g, "+").replace(/_/g, "/");
+    const bin = atob(b64);
+    return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  };
+
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+
+  const ok = await crypto.subtle.verify("HMAC", key, base64urlToBytes(s), enc.encode(data));
+  if (!ok) throw new Error("bad_sig");
+
+  const payload = JSON.parse(new TextDecoder().decode(base64urlToBytes(p)));
+  if (payload?.exp && Date.now() / 1000 > payload.exp) throw new Error("expired");
+  return payload;
+}
+
+function isIsoDate(d: string) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(d);
+}
+
+export const onRequestGet: PagesFunction = async ({ request, env }) => {
+  try {
+    const cookieHeader = request.headers.get("cookie") || "";
+    const token = readCookie(cookieHeader, "__Host-rp_session");
+    if (!token || !env.JWT_SECRET) return json({ error: "unauthorized" }, 401);
+
+    const payload = await verifyJwt(token, String(env.JWT_SECRET));
+    const user_id = String(payload?.sub || "");
+    if (!user_id) return json({ error: "unauthorized" }, 401);
+
+    const sql = neon(env.DATABASE_URL);
+
+    const permRows = await sql/*sql*/`
+      SELECT can_cash_edit
+      FROM app.permissions
+      WHERE user_id = ${user_id}
+      LIMIT 1
+    `;
+    if (!permRows?.[0]?.can_cash_edit) return json({ error: "forbidden" }, 403);
+
+    const tenantRows = await sql/*sql*/`
+      SELECT tenant_id
+      FROM app.memberships
+      WHERE user_id = ${user_id}
+      ORDER BY created_at ASC
+      LIMIT 1
+    `;
+    const tenant_id = tenantRows?.[0]?.tenant_id;
+    if (!tenant_id) return json({ error: "no_tenant" }, 403);
+
+    const url = new URL(request.url);
+    const presetRaw = String(url.searchParams.get("preset") || "today").toLowerCase();
+    const preset = presetRaw === "week" || presetRaw === "custom" ? presetRaw : "today";
+    const from = String(url.searchParams.get("from") || "").trim();
+    const to = String(url.searchParams.get("to") || "").trim();
+    const tz = env.STORE_TZ || "America/Denver";
+
+    if (preset === "custom") {
+      if (!isIsoDate(from) || !isIsoDate(to)) {
+        return json({ error: "bad_custom_range" }, 400);
+      }
+      if (from > to) return json({ error: "bad_custom_range" }, 400);
+    }
+
+    const [rangeRows] = await Promise.all([
+      preset === "today"
+        ? sql/*sql*/`
+            SELECT
+              (date_trunc('day', now() AT TIME ZONE ${tz}) AT TIME ZONE ${tz}) AS start_ts,
+              ((date_trunc('day', now() AT TIME ZONE ${tz}) + interval '1 day') AT TIME ZONE ${tz}) AS end_ts,
+              to_char((date_trunc('day', now() AT TIME ZONE ${tz}))::date, 'YYYY-MM-DD') AS start_date,
+              to_char((date_trunc('day', now() AT TIME ZONE ${tz}))::date, 'YYYY-MM-DD') AS end_date
+          `
+        : preset === "week"
+          ? sql/*sql*/`
+              SELECT
+                ((date_trunc('week', (now() AT TIME ZONE ${tz}) + interval '1 day') - interval '1 day') AT TIME ZONE ${tz}) AS start_ts,
+                (((date_trunc('week', (now() AT TIME ZONE ${tz}) + interval '1 day') - interval '1 day') + interval '7 day') AT TIME ZONE ${tz}) AS end_ts,
+                to_char((date_trunc('week', (now() AT TIME ZONE ${tz}) + interval '1 day') - interval '1 day')::date, 'YYYY-MM-DD') AS start_date,
+                to_char(((date_trunc('week', (now() AT TIME ZONE ${tz}) + interval '1 day') - interval '1 day') + interval '6 day')::date, 'YYYY-MM-DD') AS end_date
+            `
+          : sql/*sql*/`
+              SELECT
+                ((${from}::date) AT TIME ZONE ${tz}) AS start_ts,
+                (((${to}::date) + interval '1 day') AT TIME ZONE ${tz}) AS end_ts,
+                ${from}::text AS start_date,
+                ${to}::text AS end_date
+            `,
+    ]);
+
+    const start_ts = rangeRows?.start_ts;
+    const end_ts = rangeRows?.end_ts;
+
+    const [drawerRows, ledgerRows, safeRows, payoutRows, salesRows] = await Promise.all([
+      sql/*sql*/`
+        SELECT count_id, count_ts, drawer, period, grand_total, notes, user_name
+        FROM app.cash_drawer_counts
+        WHERE count_ts >= ${start_ts}
+          AND count_ts < ${end_ts}
+        ORDER BY count_ts DESC
+      `,
+      sql/*sql*/`
+        SELECT ledger_id, from_location, to_location, amount, notes, created_at
+        FROM app.cash_ledger
+        WHERE tenant_id = ${tenant_id}::uuid
+          AND created_at >= ${start_ts}
+          AND created_at < ${end_ts}
+        ORDER BY created_at DESC
+      `,
+      sql/*sql*/`
+        SELECT safe_count_id, count_ts, count_date, period, amount, notes, user_name
+        FROM app.cash_safe_counts
+        WHERE tenant_id = ${tenant_id}::uuid
+          AND count_ts >= ${start_ts}
+          AND count_ts < ${end_ts}
+        ORDER BY count_ts DESC
+      `,
+      sql/*sql*/`
+        SELECT payout_id, payout_ts, short_description, drawer_1_amount, drawer_2_amount, safe_amount, grand_total, user_name
+        FROM app.cash_payouts
+        WHERE payout_ts >= ${start_ts}
+          AND payout_ts < ${end_ts}
+        ORDER BY payout_ts DESC
+      `,
+      sql/*sql*/`
+        SELECT sale_id, sale_ts, total, payment_method
+        FROM app.sales
+        WHERE tenant_id = ${tenant_id}::uuid
+          AND sale_ts >= ${start_ts}
+          AND sale_ts < ${end_ts}
+          AND (
+            lower(payment_method) = 'cash'
+            OR lower(payment_method) LIKE 'cash:%'
+            OR lower(payment_method) LIKE 'split:%cash:%'
+            OR lower(payment_method) LIKE '%:cash:%'
+          )
+        ORDER BY sale_ts DESC
+      `,
+    ]);
+
+    const totals = {
+      drawer_open_total: 0,
+      drawer_close_total: 0,
+      safe_open_total: 0,
+      safe_close_total: 0,
+      movement_in_total: 0,
+      movement_out_total: 0,
+      payout_total: 0,
+      cash_sales_total: 0,
+    };
+
+    const drawerSummary = new Map<string, any>();
+    const ensureDrawer = (d: string) => {
+      if (!drawerSummary.has(d)) {
+        drawerSummary.set(d, {
+          drawer: d,
+          open_total: 0,
+          close_total: 0,
+          movement_in: 0,
+          movement_out: 0,
+          payout_out: 0,
+          counts: 0,
+        });
+      }
+      return drawerSummary.get(d);
+    };
+
+    for (const r of drawerRows || []) {
+      const d = String(r.drawer || "");
+      if (!d) continue;
+      const amt = Number(r.grand_total || 0);
+      const row = ensureDrawer(d);
+      row.counts += 1;
+
+      if (String(r.period || "").toUpperCase() === "OPEN") {
+        row.open_total += amt;
+        totals.drawer_open_total += amt;
+      }
+      if (String(r.period || "").toUpperCase() === "CLOSE") {
+        row.close_total += amt;
+        totals.drawer_close_total += amt;
+      }
+    }
+
+    for (const r of safeRows || []) {
+      const amt = Number(r.amount || 0);
+      if (String(r.period || "").toUpperCase() === "OPEN") totals.safe_open_total += amt;
+      if (String(r.period || "").toUpperCase() === "CLOSE") totals.safe_close_total += amt;
+    }
+
+    for (const r of ledgerRows || []) {
+      const amt = Number(r.amount || 0);
+      const fromLoc = String(r.from_location || "");
+      const toLoc = String(r.to_location || "");
+
+      const fromDrawer = fromLoc.match(/^Drawer\s+(\d+)$/i)?.[1] || null;
+      const toDrawer = toLoc.match(/^Drawer\s+(\d+)$/i)?.[1] || null;
+
+      if (toDrawer) {
+        ensureDrawer(toDrawer).movement_in += amt;
+        totals.movement_in_total += amt;
+      }
+      if (fromDrawer) {
+        ensureDrawer(fromDrawer).movement_out += amt;
+        totals.movement_out_total += amt;
+      }
+    }
+
+    for (const p of payoutRows || []) {
+      const d1 = Number(p.drawer_1_amount || 0);
+      const d2 = Number(p.drawer_2_amount || 0);
+      totals.payout_total += Number(p.grand_total || d1 + d2 + Number(p.safe_amount || 0) || 0);
+      ensureDrawer("1").payout_out += d1;
+      ensureDrawer("2").payout_out += d2;
+    }
+
+    for (const s of salesRows || []) {
+      totals.cash_sales_total += Number(s.total || 0);
+    }
+
+    const byPathMap = new Map<string, any>();
+    for (const r of ledgerRows || []) {
+      const key = `${r.from_location}=>${r.to_location}`;
+      const prev = byPathMap.get(key) || {
+        from_location: r.from_location,
+        to_location: r.to_location,
+        amount_total: 0,
+        moves: 0,
+      };
+      prev.amount_total += Number(r.amount || 0);
+      prev.moves += 1;
+      byPathMap.set(key, prev);
+    }
+
+    return json({
+      ok: true,
+      range: {
+        preset,
+        timezone: tz,
+        start_date: rangeRows.start_date,
+        end_date: rangeRows.end_date,
+      },
+      totals,
+      drawer_summary: Array.from(drawerSummary.values()).sort((a, b) => Number(a.drawer) - Number(b.drawer)),
+      movement_paths: Array.from(byPathMap.values()).sort((a, b) => b.amount_total - a.amount_total),
+      activity: {
+        drawer_counts: drawerRows,
+        safe_counts: safeRows,
+        ledger_moves: ledgerRows,
+        payouts: payoutRows,
+        cash_sales: salesRows,
+      },
+    });
+  } catch (e: any) {
+    return json({ error: e?.message || "cash_report_failed" }, 500);
+  }
+};

--- a/screens/drawer.html
+++ b/screens/drawer.html
@@ -230,6 +230,61 @@
 
    </section>
 
+   <section id="cashReportSection" class="cd-card hidden">
+     <div class="flex items-start justify-between gap-3 mb-2">
+       <div>
+         <h3 class="font-medium">Cash Movement Reporting</h3>
+         <div class="text-xs text-gray-600 mt-0.5">Daily, weekly (Sunday-Saturday), and custom range reporting for managers.</div>
+       </div>
+     </div>
+
+     <div class="cd-controls">
+       <select id="reportPreset" class="border rounded px-2 py-1">
+         <option value="today">Today</option>
+         <option value="week">This Week (Sun-Sat)</option>
+         <option value="custom">Custom Range</option>
+       </select>
+
+       <label class="text-sm">From <input id="reportFrom" type="date" class="border rounded px-2 py-1"></label>
+       <label class="text-sm">To <input id="reportTo" type="date" class="border rounded px-2 py-1"></label>
+       <button id="btnReportLoad" class="btn btn--primary btn--sm">Run Report</button>
+     </div>
+
+     <div id="reportStatus" class="text-sm text-gray-600 mt-2"></div>
+
+     <div id="reportTotals" class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-2 text-sm"></div>
+
+     <div class="overflow-auto mt-3">
+       <table class="table w-full text-sm">
+         <thead>
+           <tr class="border-b">
+             <th class="px-3 py-2 text-left font-medium">Drawer</th>
+             <th class="px-3 py-2 text-left font-medium">Open Counts</th>
+             <th class="px-3 py-2 text-left font-medium">Close Counts</th>
+             <th class="px-3 py-2 text-left font-medium">Moves In</th>
+             <th class="px-3 py-2 text-left font-medium">Moves Out</th>
+             <th class="px-3 py-2 text-left font-medium">Payouts</th>
+             <th class="px-3 py-2 text-left font-medium">Net Change</th>
+           </tr>
+         </thead>
+         <tbody id="reportDrawerRows"></tbody>
+       </table>
+     </div>
+
+     <div class="overflow-auto mt-3">
+       <table class="table w-full text-sm">
+         <thead>
+           <tr class="border-b">
+             <th class="px-3 py-2 text-left font-medium">Movement Path</th>
+             <th class="px-3 py-2 text-left font-medium">Moves</th>
+             <th class="px-3 py-2 text-left font-medium">Total</th>
+           </tr>
+         </thead>
+         <tbody id="reportPathRows"></tbody>
+       </table>
+     </div>
+   </section>
+
    <!-- History Modal (reusable) -->
    <div id="historyModal" class="fixed inset-0 z-50 hidden">
      <div class="absolute inset-0 bg-black/40" id="historyBackdrop"></div>

--- a/screens/drawer.js
+++ b/screens/drawer.js
@@ -11,6 +11,8 @@ export async function init({ container, session }) {
    // ✅ Load section previews
   await refreshSafePreview();
   await refreshMovementPreview();
+  setupCashReportUI();
+  if (canCashEdit()) await loadCashReport();
   autosize(container);
 }
 
@@ -37,7 +39,8 @@ function bind(root){
 
   // ✅ modal
   'historyModal','historyBackdrop','btnCloseHistory','historyTitle','historySubtitle',
-  'historyLoading','historyEmpty','historyRows'
+  'historyLoading','historyEmpty','historyRows',
+  'cashReportSection','reportPreset','reportFrom','reportTo','btnReportLoad','reportStatus','reportTotals','reportDrawerRows','reportPathRows'
     
   ];
   ids.forEach(id => els[id] = root.querySelector('#' + id));
@@ -91,7 +94,15 @@ function wire(){
   // Modal close
   if (els.btnCloseHistory) els.btnCloseHistory.addEventListener('click', closeHistory);
   if (els.historyBackdrop) els.historyBackdrop.addEventListener('click', closeHistory);
+
+  if (els.btnReportLoad) els.btnReportLoad.addEventListener('click', loadCashReport);
+  if (els.reportPreset) {
+    els.reportPreset.addEventListener('change', () => {
+      toggleCustomDates();
+    });
+  }
 }
+
 
 
 async function saveSafeCount() {
@@ -124,6 +135,7 @@ async function saveSafeCount() {
     els.safe_notes.value = '';
 
     await refreshSafePreview();
+    if (canCashEdit()) await loadCashReport();
     
   } catch (e) {
     const status = e?.status || 500;
@@ -213,11 +225,130 @@ async function loadToday(){
   }
 }
 
+
+function canCashEdit() {
+  return !!(sessionUser?.permissions?.can_cash_edit ?? sessionUser?.can_cash_edit);
+}
+
+function setupCashReportUI() {
+  if (!els.cashReportSection) return;
+
+  if (!canCashEdit()) {
+    els.cashReportSection.classList.add('hidden');
+    return;
+  }
+
+  els.cashReportSection.classList.remove('hidden');
+  const today = new Date().toISOString().slice(0, 10);
+  if (els.reportFrom && !els.reportFrom.value) els.reportFrom.value = today;
+  if (els.reportTo && !els.reportTo.value) els.reportTo.value = today;
+  toggleCustomDates();
+}
+
+function toggleCustomDates() {
+  const isCustom = (els.reportPreset?.value || 'today') === 'custom';
+  if (els.reportFrom) els.reportFrom.disabled = !isCustom;
+  if (els.reportTo) els.reportTo.disabled = !isCustom;
+}
+
+async function loadCashReport() {
+  if (!canCashEdit() || !els.btnReportLoad) return;
+
+  const preset = (els.reportPreset?.value || 'today').toLowerCase();
+  const from = (els.reportFrom?.value || '').trim();
+  const to = (els.reportTo?.value || '').trim();
+
+  if (preset === 'custom' && (!from || !to)) {
+    showToast('Choose from and to dates for custom report');
+    return;
+  }
+
+  try {
+    els.btnReportLoad.disabled = true;
+    if (els.reportStatus) els.reportStatus.textContent = 'Loading report…';
+
+    const q = new URLSearchParams({ preset });
+    if (preset === 'custom') {
+      q.set('from', from);
+      q.set('to', to);
+    }
+
+    const data = await api(`/api/cash-report/summary?${q.toString()}`);
+    renderCashReport(data);
+  } catch (e) {
+    if (els.reportStatus) els.reportStatus.textContent = 'Report failed to load';
+    showToast('Cash report failed');
+  } finally {
+    els.btnReportLoad.disabled = false;
+  }
+}
+
+function renderCashReport(data) {
+  const totals = data?.totals || {};
+  const range = data?.range || {};
+
+  if (els.reportStatus) {
+    els.reportStatus.textContent = `${range.start_date || ''} to ${range.end_date || ''} (${(range.timezone || '').toString()})`;
+  }
+
+  if (els.reportTotals) {
+    const cards = [
+      ['Drawer Opens', fmtMoney(totals.drawer_open_total)],
+      ['Drawer Closes', fmtMoney(totals.drawer_close_total)],
+      ['Safe Opens', fmtMoney(totals.safe_open_total)],
+      ['Safe Closes', fmtMoney(totals.safe_close_total)],
+      ['Drawer Move In', fmtMoney(totals.movement_in_total)],
+      ['Drawer Move Out', fmtMoney(totals.movement_out_total)],
+      ['Cash Sales In', fmtMoney(totals.cash_sales_total)],
+      ['Payouts Out', fmtMoney(totals.payout_total)],
+    ];
+
+    els.reportTotals.innerHTML = cards.map(([k, v]) => `
+      <div class="p-2 rounded border">
+        <div class="text-xs text-gray-600">${k}</div>
+        <div class="font-semibold">${v}</div>
+      </div>
+    `).join('');
+  }
+
+  if (els.reportDrawerRows) {
+    const rows = Array.isArray(data?.drawer_summary) ? data.drawer_summary : [];
+    els.reportDrawerRows.innerHTML = rows.length ? rows.map((r) => {
+      const inAmt = Number(r.movement_in || 0);
+      const outAmt = Number(r.movement_out || 0);
+      const payout = Number(r.payout_out || 0);
+      const net = inAmt - outAmt - payout;
+      return `
+        <tr class="border-b">
+          <td class="px-3 py-2">Drawer ${r.drawer}</td>
+          <td class="px-3 py-2">${fmtMoney(r.open_total)}</td>
+          <td class="px-3 py-2">${fmtMoney(r.close_total)}</td>
+          <td class="px-3 py-2">${fmtMoney(inAmt)}</td>
+          <td class="px-3 py-2">${fmtMoney(outAmt)}</td>
+          <td class="px-3 py-2">${fmtMoney(payout)}</td>
+          <td class="px-3 py-2">${fmtMoney(net)}</td>
+        </tr>
+      `;
+    }).join('') : '<tr><td class="px-3 py-2 text-gray-600" colspan="7">No drawer activity in range.</td></tr>';
+  }
+
+  if (els.reportPathRows) {
+    const rows = Array.isArray(data?.movement_paths) ? data.movement_paths : [];
+    els.reportPathRows.innerHTML = rows.length ? rows.map((r) => `
+      <tr class="border-b">
+        <td class="px-3 py-2">${r.from_location} → ${r.to_location}</td>
+        <td class="px-3 py-2">${Number(r.moves || 0)}</td>
+        <td class="px-3 py-2">${fmtMoney(r.amount_total)}</td>
+      </tr>
+    `).join('') : '<tr><td class="px-3 py-2 text-gray-600" colspan="3">No movements in range.</td></tr>';
+  }
+}
+
 function renderBalanceBanner(data) {
   if (!els.balanceBanner) return;
 
    // can_cash_edit may be exposed either directly on the user or nested under permissions
-  const canEdit = !!(sessionUser?.permissions?.can_cash_edit ?? sessionUser?.can_cash_edit);
+  const canEdit = canCashEdit();
 
   const status = String(data?.review_status || '');
   const expected = Number(data?.expected_at_latest ?? NaN);
@@ -304,6 +435,7 @@ async function saveMovement() {
     // Refresh today payload (so expected/variance reflects new movement)
     await loadToday();
     await refreshMovementPreview();
+    if (canCashEdit()) await loadCashReport();
 
   } catch (e) {
     const status = e?.status || 500;
@@ -506,6 +638,7 @@ async function save(){
     els.status.textContent = `Saved (${resp.count_id})`;
     // Refresh banner/status after save
     await loadToday();
+    if (canCashEdit()) await loadCashReport();
   }catch(e){
     const status = e?.status || 500;
     if(status === 409){


### PR DESCRIPTION
### Motivation
- Provide a clear, manager-only view of cash movements so users with `can_cash_edit` can quickly see daily, weekly (Sun–Sat) and custom-range activity to help detect missing cash and trace where it moved.
- Aggregate existing cash events (drawer counts, safe counts, ledger moves, payouts and cash sales) into a single report to make reconciliation and investigations easier.

### Description
- Added a new backend endpoint `GET /api/cash-report/summary` (file: `functions/api/cash-report/summary.ts`) that enforces session auth and `can_cash_edit`, resolves tenant via `app.memberships`, accepts `preset=today|week|custom` plus `from`/`to`, computes store-timezone ranges, and returns aggregated totals, per-drawer summaries, movement-path totals and raw activity arrays.
- Implemented server aggregation across `app.cash_drawer_counts`, `app.cash_safe_counts`, `app.cash_ledger`, `app.cash_payouts` and `app.sales` (cash payments) and added explicit Sunday-start weekly logic using store timezone (`STORE_TZ` fallback `America/Denver`).
- Added a new “Cash Movement Reporting” UI section to `screens/drawer.html` with preset/custom controls, KPI cards, per-drawer net-change table and movement-path table, and wired the client (`screens/drawer.js`) to show the section only to users where `session.user.permissions.can_cash_edit` (or `session.user.can_cash_edit`) is true.
- Wired the Drawer UI to load the report on init for authorized users, run custom reports via the UI, and automatically refresh the report after drawer saves, safe saves and ledger movements.

### Testing
- Ran a static syntax check on the modified client code with `node --check screens/drawer.js`, which succeeded.
- Attempted to run `node --check` against the HTML file as part of a combined command and observed a failure because `node --check` does not accept `.html` files (this is an expected limitation of that check and not a runtime JS error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29356cf948331a34eb6b9e9946607)