### PR TITLE
Cash Drawer UX: add coin rolls, $1 coins, and drawer-first flow

### DIFF
--- a/screens/drawer.html
+++ b/screens/drawer.html
@@ -98,30 +98,46 @@
       <div id="balanceBanner" class="hidden mb-2 p-2 rounded border text-sm"></div> 
       <div class="cd-controls">
          <select id="drawer" class="border rounded px-2 py-1">
+           <option value="">Select drawer…</option>
            <option value="1">Mad Rad</option>
            <option value="2">Nichols</option>
          </select>
-          <select id="period" class="border rounded px-2 py-1">
+          <select id="period" class="border rounded px-2 py-1 drawer-required" disabled>
            <option value="">Select period…</option>
            <option value="OPEN">Open</option>
            <option value="CLOSE">Close</option>
          </select>
-         <button id="btnLoad" class="btn btn--neutral btn--sm">Load Today</button> 
+         <button id="btnLoad" class="btn btn--neutral btn--sm drawer-required" disabled>Load Today</button> 
       </div>
-      <div class="cd-grid">
-        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1" min="0" step="1"></label>
+      <div class="text-xs text-gray-600 mt-2 mb-2">Select a drawer to begin counting. Common denominations are shown first for faster entry.</div>
 
-         <label class="cd-field"><span>$1s</span><input type="number" id="ones" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1" min="0" step="1"></label>
-        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1" min="0" step="1"></label>
+      <h4 class="text-sm font-semibold mt-2 mb-1">Commonly Used</h4>
+      <div class="cd-grid">
+        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Penny rolls</span><input type="number" id="penny_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Nickel rolls</span><input type="number" id="nickel_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Dime rolls</span><input type="number" id="dime_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Quarter rolls</span><input type="number" id="quarter_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$1 bills</span><input type="number" id="ones" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+      </div>
+
+      <h4 class="text-sm font-semibold mt-3 mb-1">Uncommon</h4>
+      <div class="cd-grid">
+        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Half-dollar rolls</span><input type="number" id="halfdollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Small $1 coins</span><input type="number" id="dollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Small $1 coin rolls</span><input type="number" id="smalldollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
       </div>
       <div class="mt-3 text-right">Coin total: <strong id="coin_total">$0.00</strong></div>
       <div class="mt-3 text-right">Bill total: <strong id="bill_total">$0.00</strong></div> 
@@ -131,7 +147,7 @@
       </div>
       <section class="cd-card">
        <label class="block mb-2">Notes</label>
-       <textarea id="notes" class="w-full border rounded px-2 py-1" rows="1" placeholder="Any notes…"></textarea>
+       <textarea id="notes" class="w-full border rounded px-2 py-1 drawer-required" rows="1" placeholder="Any notes…" disabled></textarea>
    
             
      </section>

--- a/screens/drawer.js
+++ b/screens/drawer.js
@@ -3,6 +3,10 @@ import { showToast } from '/assets/js/ui.js';
 
 let els = {};
 let sessionUser = null;
+const BASE_DENOM_IDS = ['pennies','nickels','dimes','quarters','halfdollars','ones','twos','fives','tens','twenties','fifties','hundreds'];
+const ROLL_IDS = ['penny_rolls','nickel_rolls','dime_rolls','quarter_rolls','halfdollar_rolls','smalldollar_rolls','largedollar_rolls'];
+const EXTRA_COIN_IDS = ['dollarcoins','largedollarcoins'];
+const ALL_COUNT_INPUT_IDS = [...BASE_DENOM_IDS, ...ROLL_IDS, ...EXTRA_COIN_IDS];
 
 export async function init({ container, session }) {
   sessionUser = session?.user || null;
@@ -27,6 +31,8 @@ function bind(root){
   const ids = [
     'drawer','period','btnLoad','btnSave','btnPing',
     'pennies','nickels','dimes','quarters','halfdollars',
+    'penny_rolls','nickel_rolls','dime_rolls','quarter_rolls','halfdollar_rolls',
+    'dollarcoins','largedollarcoins','smalldollar_rolls','largedollar_rolls',
     'ones','twos','fives','tens','twenties','fifties','hundreds',
     'coin_total','bill_total','grand_total','notes','status',
     // Phase 1: balance + movement
@@ -47,12 +53,14 @@ function bind(root){
     
   ];
   ids.forEach(id => els[id] = root.querySelector('#' + id));
+  els.drawerRequired = Array.from(root.querySelectorAll('.drawer-required'));
 }
 
 function wire(){
+  setDrawerSelectionState();
   // Enable Save only when a period is selected
   els.period.addEventListener('change', async () => {
-    els.btnSave.disabled = !els.period.value;
+    els.btnSave.disabled = !els.period.value || !hasDrawerSelection();
 
     // If user picks a period, auto-load today's counts for the currently selected drawer
     if (els.period.value) {
@@ -62,21 +70,20 @@ function wire(){
 
   // If user switches drawers, auto-load today's counts for that drawer (only if period selected)
   els.drawer.addEventListener('change', async () => {
+    setDrawerSelectionState();
+    if (!hasDrawerSelection()) {
+      clearDrawerForm();
+      return;
+    }
     if (els.period.value) {
       await loadToday();
     } else {
-      // If no period selected yet, clear fields to avoid stale data confusion
-      ['pennies','nickels','dimes','quarters','halfdollars','ones','twos','fives','tens','twenties','fifties','hundreds']
-        .forEach(k => els[k].value = '');
-      els.notes.value = '';
-      recalc();
-      els.status.textContent = '';
+      clearDrawerForm();
     }
   });
 
   // Recalculate on every input
-  ['pennies','nickels','dimes','quarters','halfdollars',
-   'ones','twos','fives','tens','twenties','fifties','hundreds']
+  ALL_COUNT_INPUT_IDS
     .forEach(id => els[id].addEventListener('input', recalc));
 
   els.btnLoad.addEventListener('click', loadToday);
@@ -107,6 +114,26 @@ function wire(){
       toggleCustomDates();
     });
   }
+}
+
+function hasDrawerSelection() {
+  return !!String(els.drawer?.value || '').trim();
+}
+
+function clearDrawerForm() {
+  ALL_COUNT_INPUT_IDS.forEach(k => { if (els[k]) els[k].value = ''; });
+  if (els.notes) els.notes.value = '';
+  recalc();
+  if (els.status) els.status.textContent = hasDrawerSelection() ? '' : 'Select a drawer to start counting.';
+}
+
+function setDrawerSelectionState() {
+  const enabled = hasDrawerSelection();
+  (els.drawerRequired || []).forEach((el) => {
+    el.disabled = !enabled;
+  });
+  if (!enabled && els.period) els.period.value = '';
+  if (els.btnSave) els.btnSave.disabled = !enabled || !els.period?.value;
 }
 
 function wireCashReportFallback(root) {
@@ -182,7 +209,14 @@ function val(id){ return Number(els[id].value || 0); }
 function money(n){ return `$${n.toFixed(2)}`; }
 
 function recalc(){
-  const coin = (val('pennies')*0.01) + (val('nickels')*0.05) + (val('dimes')*0.10) + (val('quarters')*0.25) + (val('halfdollars')*0.50);
+  const penniesTotal = val('pennies') + (val('penny_rolls') * 50);
+  const nickelsTotal = val('nickels') + (val('nickel_rolls') * 40);
+  const dimesTotal = val('dimes') + (val('dime_rolls') * 50);
+  const quartersTotal = val('quarters') + (val('quarter_rolls') * 40);
+  const halfDollarTotal = val('halfdollars') + (val('halfdollar_rolls') * 20);
+  const smallDollarCoinTotal = val('dollarcoins') + (val('smalldollar_rolls') * 25);
+  const largeDollarCoinTotal = val('largedollarcoins') + (val('largedollar_rolls') * 20);
+  const coin = (penniesTotal*0.01) + (nickelsTotal*0.05) + (dimesTotal*0.10) + (quartersTotal*0.25) + (halfDollarTotal*0.50) + smallDollarCoinTotal + largeDollarCoinTotal;
   const bill = (val('ones')*1) + (val('twos')*2) + (val('fives')*5) + (val('tens')*10) + (val('twenties')*20) + (val('fifties')*50) + (val('hundreds')*100);
   els.coin_total.textContent = money(coin);
   els.bill_total.textContent = money(bill);
@@ -203,25 +237,28 @@ async function ping(){
 
 async function loadToday(){
   try{
+    if (!hasDrawerSelection()) {
+      clearDrawerForm();
+      return;
+    }
     els.status.textContent = 'Loading…';
-    const drawer = els.drawer.value || '1';
+    const drawer = els.drawer.value;
     const data = await api(`/api/cash-drawer/today?drawer=${encodeURIComponent(drawer)}`);
     renderBalanceBanner(data);
     // Prefill OPEN/CLOSE buckets if present; leave current inputs alone unless the matching period is loaded
     const p = els.period.value;
     const row = p === 'OPEN' ? data.open : p === 'CLOSE' ? data.close : null;
     if(row){
-      for(const k of ['pennies','nickels','dimes','quarters','halfdollars','ones','twos','fives','tens','twenties','fifties','hundreds']){
+      for(const k of BASE_DENOM_IDS){
         els[k].value = Number(row[k] ?? 0);
       }
+      [...ROLL_IDS, ...EXTRA_COIN_IDS].forEach((k) => { if (els[k]) els[k].value = ''; });
       els.notes.value = row.notes ?? '';
       recalc();
       els.status.textContent = `Loaded ${p.toLowerCase()} for today`;
     }else{
       // clear inputs for a fresh entry
-      ['pennies','nickels','dimes','quarters','halfdollars','ones','twos','fives','tens','twenties','fifties','hundreds'].forEach(k => els[k].value = '');
-      els.notes.value = '';
-      recalc();
+      clearDrawerForm();
       els.status.textContent = `No ${p ? p.toLowerCase() : ''} record yet`;
     }
 
@@ -716,13 +753,20 @@ async function loadMovementHistory() {
 
 async function save(){
   try{
-    const drawer = els.drawer.value || '1';
+    const drawer = els.drawer.value;
     const period = els.period.value;
+    if(!drawer){ showToast('Choose a drawer first'); return; }
     if(!period){ showToast('Choose a period first'); return; }
+    const pennies = val('pennies') + (val('penny_rolls') * 50);
+    const nickels = val('nickels') + (val('nickel_rolls') * 40);
+    const dimes = val('dimes') + (val('dime_rolls') * 50);
+    const quarters = val('quarters') + (val('quarter_rolls') * 40);
+    const halfdollars = val('halfdollars') + (val('halfdollar_rolls') * 20);
+    const ones = val('ones') + val('dollarcoins') + val('largedollarcoins') + (val('smalldollar_rolls') * 25) + (val('largedollar_rolls') * 20);
     const body = {
       drawer, period,
-      pennies: val('pennies'), nickels: val('nickels'), dimes: val('dimes'), quarters: val('quarters'), halfdollars: val('halfdollars'),
-      ones: val('ones'), twos: val('twos'), fives: val('fives'), tens: val('tens'), twenties: val('twenties'), fifties: val('fifties'), hundreds: val('hundreds'),
+      pennies, nickels, dimes, quarters, halfdollars,
+      ones, twos: val('twos'), fives: val('fives'), tens: val('tens'), twenties: val('twenties'), fifties: val('fifties'), hundreds: val('hundreds'),
       notes: els.notes.value || null
     };
     els.btnSave.disabled = true;
@@ -743,6 +787,6 @@ async function save(){
       els.status.textContent = 'Save failed';
     }
   }finally{
-    els.btnSave.disabled = false;
+    els.btnSave.disabled = !hasDrawerSelection() || !els.period.value;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve the Cash Tracking drawer-count workflow so staff can count faster and make fewer errors by surfacing common denominations first. 
- Add support for `$1` coin types and coin rolls so users can enter rolls (not just loose coins) and save accurate totals without backend schema changes. 
- Prevent accidental data loss by disallowing entry into count fields until a drawer is explicitly selected. 

### Description
- UI: split the drawer count inputs into `Commonly Used` and `Uncommon` sections and added roll inputs and dollar-coin inputs in `screens/drawer.html` (new fields include `penny_rolls`, `nickel_rolls`, `dime_rolls`, `quarter_rolls`, `halfdollar_rolls`, `smalldollar_rolls`, `largedollar_rolls`, `dollarcoins`, `largedollarcoins`) and marked drawer-dependent controls with the `.drawer-required` class and `disabled` by default. 
- Drawer-first flow: made the drawer selector start with `Select drawer…` and implemented logic to enable/disable dependent controls until a drawer is chosen (`.drawer-required` handling and `setDrawerSelectionState`). 
- Calculation: added roll-to-coin conversions in `screens/drawer.js` using standard US roll quantities (`pennies=50`, `nickels=40`, `dimes=50`, `quarters=40`, `halfdollars=20`, `small dollars=25`, `large dollars=20`) and included `$1` coins in the coin totals. 
- Save/load behaviour: aggregate roll counts and `$1` coins into the existing backend fields before saving so no DB schema change is required (rolls and $1-coin counts are converted to base denominations and mapped into the existing `ones`, `pennies`, etc. payload); when loading historical records we populate base denominations and leave roll-specific inputs blank. 
- Code: added denomination/roll ID constants and helpers (`BASE_DENOM_IDS`, `ROLL_IDS`, `ALL_COUNT_INPUT_IDS`, `hasDrawerSelection`, `clearDrawerForm`, `setDrawerSelectionState`) in `screens/drawer.js` and updated `recalc()` and `save()` to handle the new inputs. 

### Testing
- Ran a static check: `node --check screens/drawer.js`, which passed. 
- Verified the new fields are disabled until a drawer is selected and that `recalc()` uses roll quantities to update `coin_total`/`grand_total` (manual exercise during development, no automated UI tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6c776d48331867cfe5ba4ebbd8c)