### PR TITLE
Fix cash drawer roll/coin field persistence and move $50/$100 to commonly used

### DIFF
--- a/functions/api/cash-drawer/save.ts
+++ b/functions/api/cash-drawer/save.ts
@@ -80,10 +80,33 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const twenties    = asInt(body.twenties);
     const fifties     = asInt(body.fifties);
     const hundreds    = asInt(body.hundreds);
+    const penny_rolls = asInt(body.penny_rolls);
+    const nickel_rolls = asInt(body.nickel_rolls);
+    const dime_rolls = asInt(body.dime_rolls);
+    const quarter_rolls = asInt(body.quarter_rolls);
+    const halfdollar_rolls = asInt(body.halfdollar_rolls);
+    const dollarcoins = asInt(body.dollarcoins);
+    const largedollarcoins = asInt(body.largedollarcoins);
+    const smalldollar_rolls = asInt(body.smalldollar_rolls);
+    const largedollar_rolls = asInt(body.largedollar_rolls);
     const notes       = body.notes ? String(body.notes).slice(0, 2000) : null;
 
     // Totals (authoritative on server)
-    const coin_total = pennies*0.01 + nickels*0.05 + dimes*0.10 + quarters*0.25 + halfdollars*0.50;
+    const penniesTotal = pennies + (penny_rolls * 50);
+    const nickelsTotal = nickels + (nickel_rolls * 40);
+    const dimesTotal = dimes + (dime_rolls * 50);
+    const quartersTotal = quarters + (quarter_rolls * 40);
+    const halfdollarsTotal = halfdollars + (halfdollar_rolls * 20);
+    const smallDollarCoinTotal = dollarcoins + (smalldollar_rolls * 25);
+    const largeDollarCoinTotal = largedollarcoins + (largedollar_rolls * 20);
+    const coin_total =
+      penniesTotal*0.01 +
+      nickelsTotal*0.05 +
+      dimesTotal*0.10 +
+      quartersTotal*0.25 +
+      halfdollarsTotal*0.50 +
+      smallDollarCoinTotal +
+      largeDollarCoinTotal;
     const bill_total = ones*1 + twos*2 + fives*5 + tens*10 + twenties*20 + fifties*50 + hundreds*100;
     const grand_total = coin_total + bill_total;
 
@@ -158,6 +181,15 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
           dimes = ${dimes},
           quarters = ${quarters},
           halfdollars = ${halfdollars},
+          penny_rolls = ${penny_rolls},
+          nickel_rolls = ${nickel_rolls},
+          dime_rolls = ${dime_rolls},
+          quarter_rolls = ${quarter_rolls},
+          halfdollar_rolls = ${halfdollar_rolls},
+          dollarcoins = ${dollarcoins},
+          largedollarcoins = ${largedollarcoins},
+          smalldollar_rolls = ${smalldollar_rolls},
+          largedollar_rolls = ${largedollar_rolls},
           ones = ${ones},
           twos = ${twos},
           fives = ${fives},
@@ -192,11 +224,15 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
       INSERT INTO app.cash_drawer_counts
         (tenant_id, count_id, count_ts, period, drawer, user_name,
          pennies, nickels, dimes, quarters, halfdollars,
+         penny_rolls, nickel_rolls, dime_rolls, quarter_rolls, halfdollar_rolls,
+         dollarcoins, largedollarcoins, smalldollar_rolls, largedollar_rolls,
          ones, twos, fives, tens, twenties, fifties, hundreds,
          coin_total, bill_total, grand_total, notes, updated_at)
       VALUES
         (${tenant_id}::uuid, ${count_id}, now(), ${period}, ${drawer}, ${actor_name},
          ${pennies}, ${nickels}, ${dimes}, ${quarters}, ${halfdollars},
+         ${penny_rolls}, ${nickel_rolls}, ${dime_rolls}, ${quarter_rolls}, ${halfdollar_rolls},
+         ${dollarcoins}, ${largedollarcoins}, ${smalldollar_rolls}, ${largedollar_rolls},
          ${ones}, ${twos}, ${fives}, ${tens}, ${twenties}, ${fifties}, ${hundreds},
          ${coin_total}, ${bill_total}, ${grand_total}, ${notes}, now())
       RETURNING count_id, period, drawer, grand_total

--- a/screens/drawer.html
+++ b/screens/drawer.html
@@ -36,6 +36,12 @@
     width: 80px;
     min-width: 80px;
   }
+  .cd-amt {
+    min-width: 64px;
+    text-align: right;
+    font-size: 12px;
+    color: #475569;
+  }
 
   /* Notes */
   .cd-card textarea {
@@ -113,31 +119,31 @@
 
       <h4 class="text-sm font-semibold mt-2 mb-1">Commonly Used</h4>
       <div class="cd-grid">
-        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Penny rolls</span><input type="number" id="penny_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Nickel rolls</span><input type="number" id="nickel_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Dime rolls</span><input type="number" id="dime_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Quarter rolls</span><input type="number" id="quarter_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$1 bills</span><input type="number" id="ones" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_pennies">$0.00</span></label>
+        <label class="cd-field"><span>Penny rolls</span><input type="number" id="penny_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_penny_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickels">$0.00</span></label>
+        <label class="cd-field"><span>Nickel rolls</span><input type="number" id="nickel_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickel_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dimes">$0.00</span></label>
+        <label class="cd-field"><span>Dime rolls</span><input type="number" id="dime_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dime_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarters">$0.00</span></label>
+        <label class="cd-field"><span>Quarter rolls</span><input type="number" id="quarter_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarter_rolls">$0.00</span></label>
+        <label class="cd-field"><span>$1 bills</span><input type="number" id="ones" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_ones">$0.00</span></label>
+        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fives">$0.00</span></label>
+        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_tens">$0.00</span></label>
+        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twenties">$0.00</span></label>
+        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fifties">$0.00</span></label>
+        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_hundreds">$0.00</span></label>
       </div>
 
       <h4 class="text-sm font-semibold mt-3 mb-1">Uncommon</h4>
       <div class="cd-grid">
-        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Half-dollar rolls</span><input type="number" id="halfdollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Small $1 coins</span><input type="number" id="dollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Small $1 coin rolls</span><input type="number" id="smalldollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollars">$0.00</span></label>
+        <label class="cd-field"><span>Half-dollar rolls</span><input type="number" id="halfdollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollar_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Small $1 coins</span><input type="number" id="dollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dollarcoins">$0.00</span></label>
+        <label class="cd-field"><span>Small $1 coin rolls</span><input type="number" id="smalldollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_smalldollar_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollarcoins">$0.00</span></label>
+        <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollar_rolls">$0.00</span></label>
+        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twos">$0.00</span></label>
       </div>
       <div class="mt-3 text-right">Coin total: <strong id="coin_total">$0.00</strong></div>
       <div class="mt-3 text-right">Bill total: <strong id="bill_total">$0.00</strong></div> 

--- a/screens/drawer.html
+++ b/screens/drawer.html
@@ -125,6 +125,8 @@
         <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
         <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
         <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
+        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
       </div>
 
       <h4 class="text-sm font-semibold mt-3 mb-1">Uncommon</h4>
@@ -136,8 +138,6 @@
         <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
         <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
         <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
-        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled></label>
       </div>
       <div class="mt-3 text-right">Coin total: <strong id="coin_total">$0.00</strong></div>
       <div class="mt-3 text-right">Bill total: <strong id="bill_total">$0.00</strong></div> 

--- a/screens/drawer.html
+++ b/screens/drawer.html
@@ -108,7 +108,7 @@
            <option value="1">Mad Rad</option>
            <option value="2">Nichols</option>
          </select>
-          <select id="period" class="border rounded px-2 py-1 drawer-required" disabled>
+         <select id="period" class="border rounded px-2 py-1 drawer-required" disabled>
            <option value="">Select period…</option>
            <option value="OPEN">Open</option>
            <option value="CLOSE">Close</option>
@@ -118,32 +118,48 @@
       <div class="text-xs text-gray-600 mt-2 mb-2">Select a drawer to begin counting. Common denominations are shown first for faster entry.</div>
 
       <h4 class="text-sm font-semibold mt-2 mb-1">Commonly Used</h4>
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Loose Coins</h5>
       <div class="cd-grid">
-        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_pennies">$0.00</span></label>
-        <label class="cd-field"><span>Penny rolls</span><input type="number" id="penny_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_penny_rolls">$0.00</span></label>
-        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickels">$0.00</span></label>
-        <label class="cd-field"><span>Nickel rolls</span><input type="number" id="nickel_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickel_rolls">$0.00</span></label>
-        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dimes">$0.00</span></label>
-        <label class="cd-field"><span>Dime rolls</span><input type="number" id="dime_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dime_rolls">$0.00</span></label>
-        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarters">$0.00</span></label>
-        <label class="cd-field"><span>Quarter rolls</span><input type="number" id="quarter_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarter_rolls">$0.00</span></label>
-        <label class="cd-field"><span>$1 bills</span><input type="number" id="ones" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_ones">$0.00</span></label>
-        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fives">$0.00</span></label>
-        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_tens">$0.00</span></label>
-        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twenties">$0.00</span></label>
-        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fifties">$0.00</span></label>
-        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_hundreds">$0.00</span></label>
+        <label class="cd-field"><span>Pennies (1¢)</span><input type="number" id="pennies" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_pennies">$0.00</span></label>
+        <label class="cd-field"><span>Nickels (5¢)</span><input type="number" id="nickels" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickels">$0.00</span></label>
+        <label class="cd-field"><span>Dimes (10¢)</span><input type="number" id="dimes" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dimes">$0.00</span></label>
+        <label class="cd-field"><span>Quarters (25¢)</span><input type="number" id="quarters" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarters">$0.00</span></label>
+      </div>
+
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Rolls</h5>
+      <div class="cd-grid">
+        <label class="cd-field"><span>Penny rolls</span><input type="number" id="penny_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_penny_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Nickel rolls</span><input type="number" id="nickel_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_nickel_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Dime rolls</span><input type="number" id="dime_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dime_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Quarter rolls</span><input type="number" id="quarter_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_quarter_rolls">$0.00</span></label>
+      </div>
+
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Bills</h5>
+      <div class="cd-grid">
+        <label class="cd-field"><span>$1 bills</span><input type="number" id="ones" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_ones">$0.00</span></label>
+        <label class="cd-field"><span>$5s</span><input type="number" id="fives" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fives">$0.00</span></label>
+        <label class="cd-field"><span>$10s</span><input type="number" id="tens" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_tens">$0.00</span></label>
+        <label class="cd-field"><span>$20s</span><input type="number" id="twenties" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twenties">$0.00</span></label>
+        <label class="cd-field"><span>$50s</span><input type="number" id="fifties" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_fifties">$0.00</span></label>
+        <label class="cd-field"><span>$100s</span><input type="number" id="hundreds" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_hundreds">$0.00</span></label>
       </div>
 
       <h4 class="text-sm font-semibold mt-3 mb-1">Uncommon</h4>
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Loose Coins</h5>
       <div class="cd-grid">
-        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollars">$0.00</span></label>
-        <label class="cd-field"><span>Half-dollar rolls</span><input type="number" id="halfdollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollar_rolls">$0.00</span></label>
-        <label class="cd-field"><span>Small $1 coins</span><input type="number" id="dollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dollarcoins">$0.00</span></label>
-        <label class="cd-field"><span>Small $1 coin rolls</span><input type="number" id="smalldollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_smalldollar_rolls">$0.00</span></label>
-        <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollarcoins">$0.00</span></label>
-        <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollar_rolls">$0.00</span></label>
-        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 drawer-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twos">$0.00</span></label>
+        <label class="cd-field"><span>Half-dollars (50¢)</span><input type="number" id="halfdollars" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollars">$0.00</span></label>
+        <label class="cd-field"><span>Small $1 coins</span><input type="number" id="dollarcoins" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_dollarcoins">$0.00</span></label>
+        <label class="cd-field"><span>Large/Silver $1 coins</span><input type="number" id="largedollarcoins" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollarcoins">$0.00</span></label>
+      </div>
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Rolls</h5>
+      <div class="cd-grid">
+        <label class="cd-field"><span>Half-dollar rolls</span><input type="number" id="halfdollar_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_halfdollar_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Small $1 coin rolls</span><input type="number" id="smalldollar_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_smalldollar_rolls">$0.00</span></label>
+        <label class="cd-field"><span>Large $1 coin rolls</span><input type="number" id="largedollar_rolls" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_largedollar_rolls">$0.00</span></label>
+      </div>
+      <h5 class="text-xs font-semibold mt-2 mb-1 uppercase tracking-wide text-gray-600">Bills</h5>
+      <div class="cd-grid">
+        <label class="cd-field"><span>$2s</span><input type="number" id="twos" class="border rounded px-2 py-1 count-required" min="0" step="1" disabled><span class="cd-amt" id="amt_twos">$0.00</span></label>
       </div>
       <div class="mt-3 text-right">Coin total: <strong id="coin_total">$0.00</strong></div>
       <div class="mt-3 text-right">Bill total: <strong id="bill_total">$0.00</strong></div> 
@@ -153,7 +169,7 @@
       </div>
       <section class="cd-card">
        <label class="block mb-2">Notes</label>
-       <textarea id="notes" class="w-full border rounded px-2 py-1 drawer-required" rows="1" placeholder="Any notes…" disabled></textarea>
+       <textarea id="notes" class="w-full border rounded px-2 py-1 count-required" rows="1" placeholder="Any notes…" disabled></textarea>
    
             
      </section>

--- a/screens/drawer.js
+++ b/screens/drawer.js
@@ -7,6 +7,29 @@ const BASE_DENOM_IDS = ['pennies','nickels','dimes','quarters','halfdollars','on
 const ROLL_IDS = ['penny_rolls','nickel_rolls','dime_rolls','quarter_rolls','halfdollar_rolls','smalldollar_rolls','largedollar_rolls'];
 const EXTRA_COIN_IDS = ['dollarcoins','largedollarcoins'];
 const ALL_COUNT_INPUT_IDS = [...BASE_DENOM_IDS, ...ROLL_IDS, ...EXTRA_COIN_IDS];
+const FIELD_MULTIPLIERS = {
+  pennies: 0.01,
+  penny_rolls: 0.50,
+  nickels: 0.05,
+  nickel_rolls: 2.00,
+  dimes: 0.10,
+  dime_rolls: 5.00,
+  quarters: 0.25,
+  quarter_rolls: 10.00,
+  halfdollars: 0.50,
+  halfdollar_rolls: 10.00,
+  dollarcoins: 1.00,
+  smalldollar_rolls: 25.00,
+  largedollarcoins: 1.00,
+  largedollar_rolls: 20.00,
+  ones: 1.00,
+  twos: 2.00,
+  fives: 5.00,
+  tens: 10.00,
+  twenties: 20.00,
+  fifties: 50.00,
+  hundreds: 100.00,
+};
 
 export async function init({ container, session }) {
   sessionUser = session?.user || null;
@@ -20,6 +43,7 @@ export async function init({ container, session }) {
   if (els.cashReportSection && !els.cashReportSection.classList.contains('hidden')) {
     await loadCashReport();
   }
+  recalc();
   autosize(container);
 }
 
@@ -53,6 +77,9 @@ function bind(root){
     
   ];
   ids.forEach(id => els[id] = root.querySelector('#' + id));
+  root.querySelectorAll('.cd-amt[id]').forEach((el) => {
+    els[el.id] = el;
+  });
   els.drawerRequired = Array.from(root.querySelectorAll('.drawer-required'));
 }
 
@@ -221,6 +248,15 @@ function recalc(){
   els.coin_total.textContent = money(coin);
   els.bill_total.textContent = money(bill);
   els.grand_total.textContent = money(coin + bill);
+  updateFieldTotals();
+}
+
+function updateFieldTotals() {
+  for (const [id, mult] of Object.entries(FIELD_MULTIPLIERS)) {
+    const totalEl = els[`amt_${id}`];
+    if (!totalEl) continue;
+    totalEl.textContent = money(val(id) * mult);
+  }
 }
 
 async function ping(){

--- a/screens/drawer.js
+++ b/screens/drawer.js
@@ -81,17 +81,20 @@ function bind(root){
     els[el.id] = el;
   });
   els.drawerRequired = Array.from(root.querySelectorAll('.drawer-required'));
+  els.countRequired = Array.from(root.querySelectorAll('.count-required'));
 }
 
 function wire(){
   setDrawerSelectionState();
   // Enable Save only when a period is selected
   els.period.addEventListener('change', async () => {
-    els.btnSave.disabled = !els.period.value || !hasDrawerSelection();
+    setDrawerSelectionState();
 
     // If user picks a period, auto-load today's counts for the currently selected drawer
     if (els.period.value) {
       await loadToday();
+    } else {
+      clearDrawerForm();
     }
   });
 
@@ -106,6 +109,7 @@ function wire(){
       await loadToday();
     } else {
       clearDrawerForm();
+      if (els.status) els.status.textContent = 'Choose Open or Close to begin entering counts.';
     }
   });
 
@@ -146,21 +150,32 @@ function wire(){
 function hasDrawerSelection() {
   return !!String(els.drawer?.value || '').trim();
 }
+function hasPeriodSelection() {
+  return !!String(els.period?.value || '').trim();
+}
 
 function clearDrawerForm() {
   ALL_COUNT_INPUT_IDS.forEach(k => { if (els[k]) els[k].value = ''; });
   if (els.notes) els.notes.value = '';
   recalc();
-  if (els.status) els.status.textContent = hasDrawerSelection() ? '' : 'Select a drawer to start counting.';
+  if (els.status) {
+    if (!hasDrawerSelection()) els.status.textContent = 'Select a drawer to start counting.';
+    else if (!hasPeriodSelection()) els.status.textContent = 'Choose Open or Close to begin entering counts.';
+    else els.status.textContent = '';
+  }
 }
 
 function setDrawerSelectionState() {
-  const enabled = hasDrawerSelection();
+  const drawerEnabled = hasDrawerSelection();
+  const countEnabled = drawerEnabled && hasPeriodSelection();
   (els.drawerRequired || []).forEach((el) => {
-    el.disabled = !enabled;
+    el.disabled = !drawerEnabled;
   });
-  if (!enabled && els.period) els.period.value = '';
-  if (els.btnSave) els.btnSave.disabled = !enabled || !els.period?.value;
+  (els.countRequired || []).forEach((el) => {
+    el.disabled = !countEnabled;
+  });
+  if (!drawerEnabled && els.period) els.period.value = '';
+  if (els.btnSave) els.btnSave.disabled = !countEnabled;
 }
 
 function wireCashReportFallback(root) {

--- a/screens/drawer.js
+++ b/screens/drawer.js
@@ -249,10 +249,15 @@ async function loadToday(){
     const p = els.period.value;
     const row = p === 'OPEN' ? data.open : p === 'CLOSE' ? data.close : null;
     if(row){
-      for(const k of BASE_DENOM_IDS){
-        els[k].value = Number(row[k] ?? 0);
+      for (const k of BASE_DENOM_IDS) {
+        if (els[k]) els[k].value = Number(row[k] ?? 0);
       }
-      [...ROLL_IDS, ...EXTRA_COIN_IDS].forEach((k) => { if (els[k]) els[k].value = ''; });
+      for (const k of ROLL_IDS) {
+        if (els[k]) els[k].value = Number(row[k] ?? 0);
+      }
+      for (const k of EXTRA_COIN_IDS) {
+        if (els[k]) els[k].value = Number(row[k] ?? 0);
+      }
       els.notes.value = row.notes ?? '';
       recalc();
       els.status.textContent = `Loaded ${p.toLowerCase()} for today`;
@@ -757,16 +762,29 @@ async function save(){
     const period = els.period.value;
     if(!drawer){ showToast('Choose a drawer first'); return; }
     if(!period){ showToast('Choose a period first'); return; }
-    const pennies = val('pennies') + (val('penny_rolls') * 50);
-    const nickels = val('nickels') + (val('nickel_rolls') * 40);
-    const dimes = val('dimes') + (val('dime_rolls') * 50);
-    const quarters = val('quarters') + (val('quarter_rolls') * 40);
-    const halfdollars = val('halfdollars') + (val('halfdollar_rolls') * 20);
-    const ones = val('ones') + val('dollarcoins') + val('largedollarcoins') + (val('smalldollar_rolls') * 25) + (val('largedollar_rolls') * 20);
     const body = {
       drawer, period,
-      pennies, nickels, dimes, quarters, halfdollars,
-      ones, twos: val('twos'), fives: val('fives'), tens: val('tens'), twenties: val('twenties'), fifties: val('fifties'), hundreds: val('hundreds'),
+      pennies: val('pennies'),
+      nickels: val('nickels'),
+      dimes: val('dimes'),
+      quarters: val('quarters'),
+      halfdollars: val('halfdollars'),
+      penny_rolls: val('penny_rolls'),
+      nickel_rolls: val('nickel_rolls'),
+      dime_rolls: val('dime_rolls'),
+      quarter_rolls: val('quarter_rolls'),
+      halfdollar_rolls: val('halfdollar_rolls'),
+      dollarcoins: val('dollarcoins'),
+      largedollarcoins: val('largedollarcoins'),
+      smalldollar_rolls: val('smalldollar_rolls'),
+      largedollar_rolls: val('largedollar_rolls'),
+      ones: val('ones'),
+      twos: val('twos'),
+      fives: val('fives'),
+      tens: val('tens'),
+      twenties: val('twenties'),
+      fifties: val('fifties'),
+      hundreds: val('hundreds'),
       notes: els.notes.value || null
     };
     els.btnSave.disabled = true;


### PR DESCRIPTION
### Motivation
- Fix incorrect Neon saves where roll quantities and $1-coin counts were being pre-merged into loose denomination columns (e.g., entering `1` in both pennies and penny rolls became `pennies=51` and `penny_rolls=0`).
- Preserve exact user-entered semantics for loose coins, coin rolls, and small/large dollar coins so totals remain accurate and fields remain populated when loading records.
- Improve UI ergonomics by moving commonly used `$50` and `$100` bill inputs into the primary (Commonly Used) section for faster entry.

### Description
- Updated client load logic in `screens/drawer.js` so `loadToday()` hydrates base denominations, roll columns, and extra coin columns from the server row instead of blanking roll/coin fields; this preserves `penny_rolls`, `smalldollar_rolls`, etc., on load. 
- Changed client `save()` payload in `screens/drawer.js` to send loose counts, roll counts, and extra coin counts as separate fields (e.g., `pennies`, `penny_rolls`, `dollarcoins`, `smalldollar_rolls`) instead of pre-merging them before sending. 
- Extended server API `functions/api/cash-drawer/save.ts` to read and persist roll/coin columns (`penny_rolls`, `nickel_rolls`, `dime_rolls`, `quarter_rolls`, `halfdollar_rolls`, `dollarcoins`, `largedollarcoins`, `smalldollar_rolls`, `largedollar_rolls`), to compute coin totals server-side by combining loose + roll quantities, and to include those columns in `INSERT` and `UPDATE` statements. 
- Moved `$50s` and `$100s` markup from the Uncommon section into the Commonly Used section in `screens/drawer.html`. 
- Note: historical DB rows that were previously saved with pre-merged values remain unchanged; new saves will persist separate roll and loose fields.

### Testing
- Ran `node --check screens/drawer.js` and it completed successfully. 
- Attempted `npx tsc --noEmit --pretty false functions/api/cash-drawer/save.ts` which reported a missing global `PagesFunction` type in the local typing setup, so the TypeScript check failed due to environment typings and not due to the logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b36cf1308331b6e3483ab63fd84a)