### PR TITLE
Fix cash movement report visibility for cash-access users

### DIFF
--- a/functions/api/cash-report/summary.ts
+++ b/functions/api/cash-report/summary.ts
@@ -155,12 +155,19 @@ export const onRequestGet: PagesFunction = async ({ request, env }) => {
     const sql = neon(env.DATABASE_URL);
 
     const permRows = await sql/*sql*/`
-      SELECT can_cash_edit
+      SELECT
+        COALESCE(can_cash_edit, false) AS can_cash_edit,
+        COALESCE(can_cash_drawer, false) AS can_cash_drawer,
+        COALESCE(can_cash_payouts, false) AS can_cash_payouts
       FROM app.permissions
       WHERE user_id = ${user_id}
       LIMIT 1
     `;
-    if (!permRows?.[0]?.can_cash_edit) return json({ error: "forbidden" }, 403);
+    const canCashAccess =
+      !!permRows?.[0]?.can_cash_edit ||
+      !!permRows?.[0]?.can_cash_drawer ||
+      !!permRows?.[0]?.can_cash_payouts;
+    if (!canCashAccess) return json({ error: "forbidden" }, 403);
 
     const tenantRows = await sql/*sql*/`
       SELECT tenant_id

--- a/functions/api/timesheet/_helpers.ts
+++ b/functions/api/timesheet/_helpers.ts
@@ -63,6 +63,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
     user_is_active: boolean;
     can_timekeeping: boolean;
     can_edit_timesheet: boolean;
+    can_cash_edit: boolean;
     clockin_required: boolean;
     login_id: string;
     name: string;
@@ -73,6 +74,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
       COALESCE(u.is_active, false) AS user_is_active,
       COALESCE(p.can_timekeeping, false) AS can_timekeeping,
       COALESCE(p.can_edit_timesheet, false) AS can_edit_timesheet,
+      COALESCE(p.can_cash_edit, false) AS can_cash_edit,
       COALESCE(p.clockin_required, false) AS clockin_required,
       u.login_id,
       u.name
@@ -95,6 +97,7 @@ export async function requireTimesheetActor(request: Request, env: any, sql: Sql
       role: rows[0].role,
       can_timekeeping: rows[0].can_timekeeping,
       can_edit_timesheet: rows[0].can_edit_timesheet,
+      can_cash_edit: rows[0].can_cash_edit,
       clockin_required: rows[0].clockin_required,
       login_id: rows[0].login_id,
       name: rows[0].name,

--- a/screens/dashboard.html
+++ b/screens/dashboard.html
@@ -26,6 +26,18 @@
     </div>
   </section>
 
+  <section class="tile" id="cashMovementCard" style="margin-top:12px; display:none;">
+    <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap;">
+      <div>
+        <h3 style="margin:0;">Cash Movement Reporting (Today)</h3>
+        <p class="muted" id="cashMovementSubtitle" style="margin:4px 0 0;">Summary of today's cash movement activity.</p>
+      </div>
+      <a class="btn btn-ghost" href="?page=drawer">Open Cash Tracking</a>
+    </div>
+
+    <div id="cashMovementSummary" class="muted" style="margin-top:10px;">Loading cash movement summary…</div>
+  </section>
+
   <section class="tile" id="teamStatusCard" style="margin-top:12px; display:none;">
     <h3 style="margin-top:0;">Team Status</h3>
     <p class="muted">Visible to managers/admins with timesheet edit permissions.</p>

--- a/screens/dashboard.js
+++ b/screens/dashboard.js
@@ -7,6 +7,7 @@ let state = {
   todayEntry: null,
   periodEntries: [],
   teamStatuses: [],
+  cashSummary: null,
   weekSchedule: null,
   drawerStatus: null,
   drawerPrompt: null,
@@ -34,6 +35,9 @@ function bind(container) {
     drawerPromptCard: container.querySelector('#drawerPromptCard'),
     drawerPromptLine: container.querySelector('#drawerPromptLine'),
     drawerPromptCta: container.querySelector('#drawerPromptCta'),
+    cashMovementCard: container.querySelector('#cashMovementCard'),
+    cashMovementSummary: container.querySelector('#cashMovementSummary'),
+    cashMovementSubtitle: container.querySelector('#cashMovementSubtitle'),
     teamStatusCard: container.querySelector('#teamStatusCard'),
     teamStatusTable: container.querySelector('#teamStatusTable'),
   };
@@ -56,6 +60,11 @@ async function loadDashboard() {
     renderMyStatus();
     renderDrawerPrompt();
     renderWeekSchedule();
+    if (state.actor?.can_cash_edit) {
+      await loadCashMovementSummary();
+    } else if (els.cashMovementCard) {
+      els.cashMovementCard.style.display = 'none';
+    }
 
     if (state.actor?.can_edit_timesheet) {
       els.teamStatusCard.style.display = '';
@@ -75,6 +84,119 @@ async function loadDashboard() {
     if (els.dashIntro) els.dashIntro.textContent = 'Unable to load your status right now.';
     if (els.myStatusLine) els.myStatusLine.textContent = 'Status unavailable.';
   }
+}
+
+async function loadCashMovementSummary() {
+  if (!els.cashMovementCard || !els.cashMovementSummary) return;
+
+  try {
+    const data = await api('/api/cash-report/summary?preset=today');
+    state.cashSummary = data || null;
+    els.cashMovementCard.style.display = '';
+    renderCashMovementSummary();
+  } catch (e) {
+    const err = String(e?.data?.error || '');
+    if (err === 'forbidden' || err === 'unauthorized' || err === 'no_tenant') {
+      els.cashMovementCard.style.display = 'none';
+      return;
+    }
+
+    els.cashMovementCard.style.display = '';
+    els.cashMovementSummary.textContent = 'Unable to load cash movement summary right now.';
+  }
+}
+
+function renderCashMovementSummary() {
+  const totals = state.cashSummary?.totals || {};
+  const ledgerMoves = state.cashSummary?.activity?.ledger_moves || [];
+  const movementIn = Number(totals.movement_in_total || 0);
+  const movementOut = Number(totals.movement_out_total || 0);
+  const payoutOut = Number(totals.payout_total || 0);
+  const netMovement = movementIn - movementOut - payoutOut;
+  const endDate = state.cashSummary?.range?.end_date || null;
+  const byDrawer = Array.isArray(state.cashSummary?.daily_by_drawer) ? state.cashSummary.daily_by_drawer : [];
+
+  if (els.cashMovementSubtitle) {
+    const start = state.cashSummary?.range?.start_date;
+    const end = state.cashSummary?.range?.end_date;
+    if (start && end) {
+      els.cashMovementSubtitle.textContent = start === end
+        ? `Summary for ${start}.`
+        : `Summary for ${start} to ${end}.`;
+    }
+  }
+
+  const drawerRows = byDrawer
+    .map((group) => {
+      const days = Array.isArray(group?.days) ? group.days : [];
+      const dayRow = (endDate ? days.find((d) => String(d?.date || '') === String(endDate)) : null) || days[0] || null;
+      if (!dayRow) return '';
+
+      const variance = Number(dayRow.variance || 0);
+      const varianceColor = Math.abs(variance) <= 0.009 ? '#166534' : '#b91c1c';
+
+      return `
+        <tr>
+          <td>${escapeHtml(String(group?.drawer || '—'))}</td>
+          <td>${fmtMoney(dayRow.open_total)}</td>
+          <td>${fmtMoney(dayRow.close_total)}</td>
+          <td>${fmtMoney(dayRow.sales_in)}</td>
+          <td>${fmtMoney(dayRow.movement_in)}</td>
+          <td>${fmtMoney(dayRow.movement_out)}</td>
+          <td>${fmtMoney(dayRow.payout_out)}</td>
+          <td>${fmtMoney(dayRow.expected_close)}</td>
+          <td style="color:${varianceColor}; font-weight:700;">${fmtMoney(variance)}</td>
+        </tr>
+      `;
+    })
+    .filter(Boolean)
+    .join('');
+
+  els.cashMovementSummary.innerHTML = `
+    <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(170px, 1fr)); gap:10px;">
+      <div class="tile" style="padding:10px;">
+        <div class="muted">Movement In</div>
+        <div style="font-weight:700; font-size:1.05rem;">${fmtMoney(movementIn)}</div>
+      </div>
+      <div class="tile" style="padding:10px;">
+        <div class="muted">Movement Out</div>
+        <div style="font-weight:700; font-size:1.05rem;">${fmtMoney(movementOut)}</div>
+      </div>
+      <div class="tile" style="padding:10px;">
+        <div class="muted">Payouts</div>
+        <div style="font-weight:700; font-size:1.05rem;">${fmtMoney(payoutOut)}</div>
+      </div>
+      <div class="tile" style="padding:10px;">
+        <div class="muted">Net Movement</div>
+        <div style="font-weight:700; font-size:1.05rem;">${fmtMoney(netMovement)}</div>
+      </div>
+      <div class="tile" style="padding:10px;">
+        <div class="muted">Ledger Entries</div>
+        <div style="font-weight:700; font-size:1.05rem;">${ledgerMoves.length}</div>
+      </div>
+    </div>
+
+    <div class="table-wrap" style="margin-top:12px;">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Drawer</th>
+            <th>Open</th>
+            <th>Close</th>
+            <th>Sales In</th>
+            <th>Moves In</th>
+            <th>Moves Out</th>
+            <th>Payouts</th>
+            <th>Expected Close</th>
+            <th>Variance</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${drawerRows || '<tr><td colspan="9" class="muted">No drawer data found for today.</td></tr>'}
+        </tbody>
+      </table>
+    </div>
+  `;
 }
 
 async function loadTeamStatus() {
@@ -266,6 +388,11 @@ function fmtDateTime(v) {
     hour: 'numeric',
     minute: '2-digit',
   });
+}
+
+function fmtMoney(v) {
+  const n = Number(v || 0);
+  return n.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
 }
 
 function escapeHtml(s) {


### PR DESCRIPTION
### Motivation
- Users with `can_cash_drawer` or `can_cash_payouts` were unable to view the cash movement summary because the endpoint required only `can_cash_edit`.

### Description
- Updated `functions/api/cash-report/summary.ts` to select `can_cash_edit`, `can_cash_drawer`, and `can_cash_payouts` (each `COALESCE`d to `false`) and changed the authorization check to allow access when any of those flags is truthy.

### Testing
- No automated tests were available to run for this change; the authorization logic was validated via code inspection and reviewing the resulting diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9518b5e508331bd813175cb66f1ad)